### PR TITLE
Add is_redirector for T2_US_Florida

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -242,7 +242,8 @@ consistency:
       server: transfer-1.ultralight.org
       interval: 7
     T2_US_Florida:
-      server: cmsio7.rc.ufl.edu 
+      server: cmsio7.rc.ufl.edu
+      is_redirector: false      
       interval: 7
     T2_US_MIT:
       server: xrootd15.cmsaf.mit.edu:1094


### PR DESCRIPTION
To use the redirector at Florida instead of the consistency check provided xrotod servers.
Also see https://rucio.slack.com/archives/CU3D7HLCW/p1652980207113069