### PR TITLE
Update prod-rucio-daemons.yaml

### DIFF
--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -8,6 +8,7 @@ conveyorReceiverCount: 1
 conveyorFinisherCount: 4
 judgeEvaluatorCount: 2
 tracerKronosCount: 3
+judgeCleanerCount: 2
 
 darkReaper:
   includeRses: "reaper=True"


### PR DESCRIPTION
Temporal increase of judgeClenaer pods to handle 116K deleted rules.