### PR TITLE
Redirector change for T2_US_Florida

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -251,7 +251,7 @@ consistency:
       server: transfer-1.ultralight.org
       interval: 7
     T2_US_Florida:
-      server: cmsio7.rc.ufl.edu
+      server: cmsio2.rc.ufl.edu
       interval: 7
     T2_US_MIT:
       server: xrootd15.cmsaf.mit.edu:1094


### PR DESCRIPTION
from cmsio7.rc.ufl.edu to cmsio2.rc.ufl.edu