### PR TITLE
Exclude T1_FNAL, T1_FR and T1_KIT Disk from CC

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -9,9 +9,9 @@ consistency:
      - /store/accounting
      - /store/express/tier0_harvest
   sites:
-    T1_DE_KIT_Disk:
-      interval: 7
-      server: cmsxrootd-kit.gridka.de:1094 
+    #T1_DE_KIT_Disk:
+    #  interval: 7
+    #  server: cmsxrootd-kit.gridka.de:1094
     #  server: cmsxrootd-redirectors.gridka.de:1094
     T2_US_Purdue:      
       interval: 7
@@ -25,12 +25,12 @@ consistency:
     T1_UK_RAL_Tape:
       interval: 0
       maxdarkfraction: "0.0000001"
-    T1_US_FNAL_Disk:
-      interval: 7
-      server: cmsdcadisk.fnal.gov
-      server_root: /dcache/uscmsdisk
-      maxdarkfraction: 0.05
-      maxmissfraction: 0.02
+    #T1_US_FNAL_Disk:
+    #  interval: 7
+    #  server: cmsdcadisk.fnal.gov
+    #  server_root: /dcache/uscmsdisk
+    #  maxdarkfraction: 0.05
+    #  maxmissfraction: 0.02
     T2_TW_NCHC:
       server: se01.grid.nchc.org.tw:11001
       interval: 7
@@ -271,10 +271,10 @@ consistency:
       server: ccxrootdcms.in2p3.fr:1094
       server_root: /pnfs/in2p3.fr/data/cms/data
       interval: 7
-    T1_FR_CCIN2P3_Disk:
-      server: ccxrootdcms.in2p3.fr:1094
-      server_root: /pnfs/in2p3.fr/data/cms/disk/data
-      interval: 7
+    #T1_FR_CCIN2P3_Disk:
+    #  server: ccxrootdcms.in2p3.fr:1094
+    #  server_root: /pnfs/in2p3.fr/data/cms/disk/data
+    #  interval: 7
     T1_RU_JINR_Disk:
       server: xrootd01.jinr-t1.ru:1094
       server_root: /pnfs/jinr-t1.ru/data/cms


### PR DESCRIPTION
This is not a fix. Im  only excluding those sites from CC while we understand why xroot step is taking a lot of time to complete. FYI @ivmfnal @ericvaandering 