### PR TITLE
Upgrade prod to cms6 images

### DIFF
--- a/apps/production/prod-release.yaml
+++ b/apps/production/prod-release.yaml
@@ -1,6 +1,6 @@
 image:
-  tag: release-1.31.3.cms4
-  
+  tag: release-1.31.3.cms6
+
 # FIXME: Maybe not the best place for this but everything may need it
 
 config:


### PR DESCRIPTION
- Introduces new activity : User AutoApprove
- Additional limit of single RSE rules to 50TB for auto_approve rules