### PR TITLE
Switch all our helm charts over to OCI

### DIFF
--- a/apps/base/cms-rucio-consistency/cms-consistency-helm.yaml
+++ b/apps/base/cms-rucio-consistency/cms-consistency-helm.yaml
@@ -6,11 +6,11 @@ spec:
   releaseName: consistency
   chart:
     spec:
-      chart: rucio-consistency
+      chart: helm/rucio-consistency
       version: 3.2.0
       sourceRef:
         kind: HelmRepository
-        name: cms-rucio
+        name: cms-rucio-oci
         namespace: flux-system
   interval: 5m
   install:

--- a/apps/base/cms-rucio-cron/cms-rucio-cron-helm.yaml
+++ b/apps/base/cms-rucio-cron/cms-rucio-cron-helm.yaml
@@ -6,11 +6,11 @@ spec:
   releaseName: rucio-cron
   chart:
     spec:
-      chart: rucio-cron-jobs
+      chart: helm/rucio-cron-jobs
       version: 2.1.0
       sourceRef:
         kind: HelmRepository
-        name: cms-rucio
+        name: cms-rucio-oci
         namespace: flux-system
   interval: 5m
   install:

--- a/apps/base/cms-rucio-cvmfs/cms-grid-cvmfs-helm.yaml
+++ b/apps/base/cms-rucio-cvmfs/cms-grid-cvmfs-helm.yaml
@@ -6,11 +6,11 @@ spec:
   releaseName: grid-cvmfs
   chart:
     spec:
-      chart: rucio-cvmfs
+      chart: helm/rucio-cvmfs
       version: 1.0.2
       sourceRef:
         kind: HelmRepository
-        name: cms-rucio
+        name: cms-rucio-oci
         namespace: flux-system
   interval: 5m
   install:

--- a/apps/base/cms-rucio-traces/rucio-traces-helm.yaml
+++ b/apps/base/cms-rucio-traces/rucio-traces-helm.yaml
@@ -6,10 +6,10 @@ spec:
   releaseName: traces
   chart:
     spec:
-      chart: rucio-traces
+      chart: helm/rucio-traces
       sourceRef:
         kind: HelmRepository
-        name: cms-rucio
+        name: cms-rucio-oci
         namespace: flux-system
   interval: 5m
   install:

--- a/infrastructure/sources/cms-rucio.yaml
+++ b/infrastructure/sources/cms-rucio.yaml
@@ -8,3 +8,13 @@ metadata:
 spec:
   interval: 5m
   url: https://registry.cern.ch/chartrepo/cmsrucio
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cms-rucio-oci
+  namespace: flux-system
+spec:
+  interval: 5m
+  type: oci
+  url: oci://registry.cern.ch/cmsrucio

--- a/infrastructure/statsd/release.yaml
+++ b/infrastructure/statsd/release.yaml
@@ -6,11 +6,11 @@ spec:
   releaseName: statsd-exporter
   chart:
     spec:
-      chart: rucio-statsd-exporter
+      chart: helm/rucio-statsd-exporter
       version: "1.1.1"
       sourceRef:
         kind: HelmRepository
-        name: cms-rucio
+        name: cms-rucio-oci
         namespace: flux-system
   interval: 5m
   install:


### PR DESCRIPTION
This PR switches over all our helm charts to OCI repositories in Harbor vs. chartmuseum