### PR TITLE
Consistency check modifications CMSTRANSF-683

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -151,7 +151,8 @@ consistency:
       server: se01.indiacms.res.in:11001
       interval: 7
     T2_CH_CSCS:
-      server: cms03.lcg.cscs.ch:1094
+      server: storage01.lcg.cscs.ch:1096
+      server_root: /pnfs/lcg.cscs.ch/cms/trivcat
       interval: 7
     T2_FR_IPHC:
       server: sbgse1.in2p3.fr:1094


### PR DESCRIPTION
The CE runs and has problems finishing, currently, it's using the redirection machine. The commit updates the information pointing directly to the dcache main xrootd endpoint for CMS