### PR TITLE
Fix: Loadtest proxy

### DIFF
--- a/apps/production/prod-loadtest.yaml
+++ b/apps/production/prod-loadtest.yaml
@@ -1,6 +1,6 @@
 loadtest:
   rucioHome: "/opt/rucio-prod/"
-  proxySecret: "daemons-rucio-x509up"
+  proxySecret: "server-rucio-x509up"
   sourceExpression:   "loadtest=True"
   destinationExpression:   "loadtest=True"
 


### PR DESCRIPTION
loadtest is still using the expired `daemon-rucio-x509up`