### PR TITLE
Adapt KIT setup to new split doors + enable checks for KIT tape

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -11,7 +11,12 @@ consistency:
   sites:
     T1_DE_KIT_Disk:
       interval: 7
-      server: cmsxrootd-kit.gridka.de:1094
+      server: cmsxrootd-kit-disk.gridka.de:1094
+      server_root: /
+      timeout: 3600
+    T1_DE_KIT_Tape:
+      interval: 7
+      server: cmsxrootd-kit-tape.gridka.de:1094
       server_root: /
       timeout: 3600
     T2_US_Purdue:      


### PR DESCRIPTION
Dear all,

This is a pull request to adapt T1_DE_KIT setup for consistency checks to the dCache doors, which will be split into disk and tape.

This also allows to run consistency checks for T1_DE_KIT_Tape in addition.

To be merged during the KIT Downtime on 6th+7th December.

Best regards,

Artur