### PR TITLE
Probes for 33.3.cms2

### DIFF
--- a/apps/base/rucio-probes/cms-rucio-probes.yaml
+++ b/apps/base/rucio-probes/cms-rucio-probes.yaml
@@ -50,14 +50,11 @@ voProbes:
   check_rules_states_by_account:
     interval: 10
     voName: cms
-  check_free_space:
+  check_used_space:
     interval: 15
     voName: cms
   check_rule_counts:
     interval: 20
-    voName: cms
-  check_report_used_space:
-    interval: 30
     voName: cms
   check_expiring_rules_per_rse:
     interval: 1
@@ -67,9 +64,6 @@ voProbes:
     voName: cms
   check_rules_with_0_completion_volume:
     interval: 1
-    voName: cms
-  check_report_free_space:
-    interval: 120
     voName: cms
   check_unlocked_replicas_per_rse:
     interval: 1


### PR DESCRIPTION
@dynamic-entropy I'd like to get these probes running in integration, but I also don't want to mess up your logging.  If you are done with the .rc1 release, then please upgrade integration to 33.3.0.cms2  If not, maybe you can build an .rc3 with my changes to the probes Dockerfile?