### PR TITLE
simplfy idpsecret mounts

### DIFF
--- a/apps/base/cms-rucio-common.yaml
+++ b/apps/base/cms-rucio-common.yaml
@@ -6,8 +6,6 @@ config:
         special_accounts: "tier0"
     common:
         logjson: true
-    oidc:
-        idpsecrets: "/opt/rucio/etc/idpsecrets.json"
 
     policy:
         package: CMSRucioPolicy
@@ -70,9 +68,3 @@ ftsRenewal:
     - name: USERKEY_NAME
       value: "new_userkey.pem"
 
-
-secretMounts:
-  - secretFullName: server-idpsecrets
-    mountPath: /opt/rucio/etc/
-    subPaths:
-      - idpsecrets.json

--- a/apps/base/rucio-authserver/cms-rucio-authserver.yaml
+++ b/apps/base/rucio-authserver/cms-rucio-authserver.yaml
@@ -2,6 +2,15 @@ replicaCount: 1
 image:
   repository: registry.cern.ch/cmsrucio/rucio-server
 
+config:
+  common:
+      loglevel: "INFO"
+  oidc:
+    expected_audience: "rucio"
+    admin_issuer: "cms"
+    idpsecrets: "/opt/rucio/etc/idpsecrets.json"
+
+
 httpd_config:
   encoded_slashes: "True"
   legacy_dn: "True"
@@ -13,6 +22,10 @@ secretMounts:
   - secretFullName: server-server-hostkey
     mountPath: /etc/grid-security/hostkey.pem
     subPath: hostkey.pem
+  - secretFullName: idpsecrets
+    mountPath: /opt/rucio/etc
+    subPaths:
+      - idpsecrets.json
 
 optional_config:
   rucio_ca_path: "/cvmfs/grid.cern.ch/etc/grid-security/certificates/"
@@ -26,7 +39,7 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
     - cms-rucio-auth.cern.ch
-  tls: 
+  tls:
     - secretName: rucio-server.tls-secret
 
 useSSL: true
@@ -44,10 +57,6 @@ serverResources:
     memory: 500Mi
   limits:
     memory: 800Mi
-
-config:
-  common:
-      loglevel: "DEBUG"
 
 persistentVolumes:
   grid-cern-ch:

--- a/apps/base/rucio-daemons/cms-rucio-daemons.yaml
+++ b/apps/base/rucio-daemons/cms-rucio-daemons.yaml
@@ -31,8 +31,8 @@ automaticRestart:
 secretMounts:
   - secretFullName: server-rucio-x509up
     mountPath: /opt/proxy
-  - secretFullName: server-idpsecrets
-    mountPath: /opt/rucio/etc/idp
+  - secretFullName: idpsecrets
+    mountPath: /opt/rucio/etc
     subPaths:
       - idpsecrets.json
 
@@ -174,6 +174,7 @@ config:
     loglevel: "INFO"
   oidc:
     admin_issuer: "def"
+    idpsecrets: "/opt/rucio/etc/idpsecrets.json"
   hermes:
     services_list: "activemq"
   messaging_hermes:

--- a/apps/base/rucio-server/cms-rucio-server.yaml
+++ b/apps/base/rucio-server/cms-rucio-server.yaml
@@ -13,6 +13,10 @@ secretMounts:
   - secretFullName: server-server-hostkey
     mountPath: /etc/grid-security/hostkey.pem
     subPath: hostkey.pem
+  - secretFullName: idpsecrets
+    mountPath: /opt/rucio/etc
+    subPaths:
+      - idpsecrets.json
 
 optional_config:
   rucio_ca_path: "/cvmfs/grid.cern.ch/etc/grid-security/certificates/"
@@ -58,12 +62,16 @@ config:
     loglevel: "INFO"
   database:
     pool_size: 10
+  oidc:
+    admin_issuer: "cms"
+    expected_audience: "rucio"
+    idpsecrets: "/opt/rucio/etc/idpsecrets.json"
 
 persistentVolumes:
   grid-cern-ch:
     name: csi-cvmfs-grid-pvc
     mountPath: /cvmfs/grid.cern.ch
-    
+
 additionalEnvs:
   - name: X509_USER_PROXY
     value: "/opt/proxy/x509up"

--- a/apps/integration/int-rucio-authserver.yaml
+++ b/apps/integration/int-rucio-authserver.yaml
@@ -9,14 +9,3 @@ httpd_config:
 config:
   common:
     loglevel: "DEBUG"
-  oidc:
-    expected_audience: "rucio"
-    admin_issuer: "cms"
-
-secretMounts:
-  - secretFullName: server-server-hostcert
-    mountPath: /etc/grid-security/hostcert.pem
-    subPath: hostcert.pem
-  - secretFullName: server-server-hostkey
-    mountPath: /etc/grid-security/hostkey.pem
-    subPath: hostkey.pem

--- a/apps/integration/int-rucio-server.yaml
+++ b/apps/integration/int-rucio-server.yaml
@@ -1,23 +1,11 @@
 replicaCount: 1
 ingress:
-  hosts: 
+  hosts:
     - cms-rucio-int.cern.ch
 
 config:
   conveyor:
     use_preparer: "True"
-  oidc:
-    admin_issuer: "cms"
-    expected_audience: "rucio"
-
-# FIXME: Defined here and in prod because int does not have IDP secrets
-secretMounts:
-  - secretFullName: server-rucio-x509up
-    mountPath: /opt/proxy
-  - secretName: server-idpsecrets
-    mountPath: /opt/rucio/etc/
-    subPaths:
-      - idpsecrets.json
 
 optional_config:
   SQLALCHEMY_WARN_20: 1


### PR DESCRIPTION
Since both int and prod are configured similarly when idp is concerned, moving all config to base. 