### PR TITLE
Increase memory for receiver

### DIFF
--- a/apps/base/rucio-daemons/cms-rucio-daemons.yaml
+++ b/apps/base/rucio-daemons/cms-rucio-daemons.yaml
@@ -99,7 +99,6 @@ conveyorPoller:
       value: "/opt/proxy/x509up"
 
 conveyorReceiver:
-  threads: 4
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
@@ -107,6 +106,12 @@ conveyorReceiver:
     policy:
       schema: "cms"
       permission: "cms"
+  threads: 4
+  resources:
+    requests:
+      memory: 256Mi
+    limits:
+      memory: 512Mi
 
 hermes:
   threads: 3


### PR DESCRIPTION
The pod seems to be killed with an OOM error. 

```
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Thu, 08 Feb 2024 12:44:58 +0100
      Finished:     Thu, 08 Feb 2024 17:10:01 +0100
```

Need to review if simply increasing the resources does not help