### PR TITLE
Persist logs to cms opensearch

### DIFF
--- a/apps/base/cms-rucio-common.yaml
+++ b/apps/base/cms-rucio-common.yaml
@@ -4,6 +4,8 @@ image:
 config:
   accounts:
     special_accounts: "tier0"
+  common:
+    logjson: true
   policy:
     package: CMSRucioPolicy
     lfn2pfn_algorithm_default: "identity"

--- a/infrastructure/fluentbit/fluentbit-config.yaml
+++ b/infrastructure/fluentbit/fluentbit-config.yaml
@@ -1,0 +1,122 @@
+envFrom:
+  - secretRef:
+      name: opensearch-creds
+
+logLevel: info
+
+## Mounting /etc/machine-id with FileOrCreate
+daemonSetVolumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+  - name: etcmachineid
+    hostPath:
+      path: /etc/machine-id
+      type: FileOrCreate
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+      type: DirectoryOrCreate
+
+config:
+  service: |
+    [SERVICE]
+        Daemon Off
+        Flush {{ .Values.flush }}
+        Log_Level {{ .Values.logLevel }}
+        Parsers_File /fluent-bit/etc/parsers.conf
+        Parsers_File /fluent-bit/etc/conf/custom_parsers.conf
+        HTTP_Server On
+        HTTP_Listen 0.0.0.0
+        HTTP_Port {{ .Values.metricsPort }}
+        Health_Check On
+
+  inputs: |
+    [INPUT]
+        Name tail
+        Path /var/log/containers/*_rucio_*.log
+        Tag kube.*
+        Parser logcri
+        Mem_Buf_Limit 5MB
+        Skip_Long_Lines On
+
+  filters: |
+    [FILTER]
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Annotations Off
+        Keep_Log On
+        K8S-Logging.Exclude On
+
+    [FILTER]
+        Name record_modifier
+        Match kube.*
+        Record producer cmsrucio
+        Record type logs
+        Remove_key annotations
+
+    [FILTER]
+        Name rewrite_tag
+        Match kube.*
+        Rule $kubernetes['container_name'] rucio-server logs.access false
+        Rule $kubernetes['container_name'] rucio-daemons logs.event false
+        Rule $kubernetes['container_name'] httpd-error-log logs.error false
+
+  customParsers: |
+    [PARSER]
+        Name logcri
+        Format regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+        Time_Keep   On
+
+  outputs: |
+    [OUTPUT]
+        Name opensearch
+        Match logs.access
+        Host ${opensearchHost}
+        Port ${opensearchPort}
+        Path ${opensearchPath}
+        HTTP_Passwd ${opensearchPassword}
+        HTTP_User ${opensearchUser}
+        Logstash_Format On
+        Logstash_Prefix test-cmsrucio-prod-logs-access
+        Logstash_DateFormat %Y-%m-%d
+        Suppress_Type_Name On
+        Retry_Limit False
+        tls On
+        tls.verify Off
+
+    [OUTPUT]
+        Name opensearch
+        Match logs.event
+        Host ${opensearchHost}
+        Port ${opensearchPort}
+        Path ${opensearchPath}
+        HTTP_Passwd ${opensearchPassword}
+        HTTP_User ${opensearchUser}
+        Logstash_Format On
+        Logstash_Prefix test-cmsrucio-prod-logs-event
+        Logstash_DateFormat %Y-%m-%d
+        Suppress_Type_Name On
+        Retry_Limit False
+        tls On
+        tls.verify Off
+
+    [OUTPUT]
+        Name opensearch
+        Match logs.error
+        Host ${opensearchHost}
+        Port ${opensearchPort}
+        Path ${opensearchPath}
+        HTTP_Passwd ${opensearchPassword}
+        HTTP_User ${opensearchUser}
+        Logstash_Format On
+        Logstash_Prefix test-cmsrucio-prod-logs-error
+        Logstash_DateFormat %Y-%m-%d
+        Suppress_Type_Name On
+        Retry_Limit False
+        tls On
+        tls.verify Off

--- a/infrastructure/fluentbit/kustomization.yaml
+++ b/infrastructure/fluentbit/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: fluentbit
+
+
+configMapGenerator:
+- name: instance-fluentbit-values
+  files:
+    - values.yaml=fluentbit-config.yaml
+
+resources:
+  - namespace.yaml
+  - release.yaml
+

--- a/infrastructure/fluentbit/namespace.yaml
+++ b/infrastructure/fluentbit/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fluentbit

--- a/infrastructure/fluentbit/release.yaml
+++ b/infrastructure/fluentbit/release.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: fluent-bit
+spec:
+  releaseName: fluent-bit
+  chart:
+    spec:
+      chart: fluent-bit
+      version: ">=0.41.0 <0.42.0"
+      sourceRef:
+        kind: HelmRepository
+        name: fluent-bit
+        namespace: flux-system
+
+  interval: 5m
+  valuesFrom:
+    - kind: ConfigMap
+      name: instance-fluentbit-values
+

--- a/infrastructure/integration/kustomization.yaml
+++ b/infrastructure/integration/kustomization.yaml
@@ -8,10 +8,5 @@ resources:
   - ../statsd
   - cm-int-eagle.yaml
   - ../kube-eagle
+  - ../fluentbit 
 
-#configMapGenerator:
-#  - name: flux-rucio-server
-#    files:
-#      - values.yaml=flux-rucio-server.yaml
-#configurations:
-#  - kustomizeconfig.yaml

--- a/infrastructure/production/kustomization.yaml
+++ b/infrastructure/production/kustomization.yaml
@@ -8,13 +8,4 @@ resources:
   - ../statsd
   - cm-prod-eagle.yaml
   - ../kube-eagle
-
-#configMapGenerator:
-#  - name: flux-rucio-server
-#    files:
-#      - values.yaml=flux-rucio-server.yaml
-#configurations:
-#  - kustomizeconfig.yaml
-
-
-
+  - ../fluentbit

--- a/infrastructure/sources/fluentbit.yaml
+++ b/infrastructure/sources/fluentbit.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: fluent-bit
+  namespace: flux-system
+spec:
+  interval: 15m0s
+  url: https://fluent.github.io/helm-charts

--- a/infrastructure/sources/kustomization.yaml
+++ b/infrastructure/sources/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - rucio.yaml
   - rucio-git.yaml
   - cms-rucio.yaml
+  - fluentbit.yaml


### PR DESCRIPTION
This is a collection of all the changes we introduced in integration related to adding 
fluent bit infrastructure and configuring it. 
Each commit separates concerns:
   - introducing infrastructure
   - config to use Opensearch as sink
   - config to parse and filter logs


Fixes https://github.com/dmwm/CMSRucio/issues/495
   
Fixes https://github.com/dmwm/CMSRucio/issues/729
(Partially)
Since our ultimate aim is to send them to MONIT Timber instance
But we need numbers: capacity and rate in order for monit to create a producer for us
Over the next few days, we aim to collect that in cms-opensearch 