### PR TITLE
Port changed  for Swierk CC

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -101,7 +101,7 @@ consistency:
       server: maite.iihe.ac.be:1095
       interval: 7
     T2_PL_Swierk:
-      server: se.cis.gov.pl:11000
+      server: se.cis.gov.pl:1094
       interval: 7
     #T2_EE_Estonia_Test:
       #server: [2001:bb8:4004:ff:d::3]:1094


### PR DESCRIPTION
CC port changed for Swierk according to the following ticket [1]. The site is no longer providing services at 11000, they moved last year to 1094

[1] https://ggus.eu/index.php?mode=ticket_info&ticket_id=165408