### PR TITLE
Update prod to use 33_6_1_cms2

### DIFF
--- a/apps/production/prod-release.yaml
+++ b/apps/production/prod-release.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: release-33.6.1.cms1
+  tag: release-33.6.1.cms2
 
 # FIXME: Maybe not the best place for this but everything may need it
 config:


### PR DESCRIPTION
Allow numeric literals in data-tier names 
https://github.com/dmwm/CMSRucio/issues/744