### PR TITLE
Update prod-consistency-jobs.yaml for KIT

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -11,12 +11,12 @@ consistency:
   sites:
     T1_DE_KIT_Disk:
       interval: 7
-      server: cmsxrootd-kit-disk.gridka.de:1094
+      server: cmsdcache-kit-disk.gridka.de:1094
       server_root: /
       timeout: 3600
     T1_DE_KIT_Tape:
       interval: 7
-      server: cmsxrootd-kit-tape.gridka.de:1094
+      server: cmsdcache-kit-tape.gridka.de:1094
       server_root: /
       timeout: 3600
     T2_US_Purdue:      


### PR DESCRIPTION
Adjust the dCache XRootD entry-point server names for T1_DE_KIT according to latest status.