### PR TITLE
Remove likely-retired RSEs from the list of consistency jobs

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -56,10 +56,6 @@ consistency:
     T2_DE_RWTH:
       server: grid-cms-xrootd.physik.rwth-aachen.de:1094
       interval: 7
-    #T2_FR_GRIF_IRFU:
-    #  server: node12.datagrid.cea.fr
-    #  server_root: /cms/trivcat
-    #  interval: 7
     #T2_HU_Budapest_Test:
     #  server: grid143.kfki.hu:11000
     #  interval: 1
@@ -78,9 +74,6 @@ consistency:
     T2_IT_Bari:
       server: ss-01.recas.ba.infn.it:8080
       interval: 7
-    #T2_FR_GRIF_LLR:
-    #  server: polgrid4.in2p3.fr:11001
-    #  interval: 7
     T2_RU_JINR:
       server: lcgsexrd.jinr.ru:1095
       interval: 7
@@ -228,9 +221,6 @@ consistency:
     T2_EE_Estonia:
       server: xrootd.hep.kbfi.ee:1094
       interval: 7
-    #T2_GR_Ioannina:
-    #  server: grid02.physics.uoi.gr
-    #  interval: 7
     T2_HU_Budapest:
       server: grid143.kfki.hu:11000
       interval: 7

--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -24,7 +24,7 @@ consistency:
       server: af-a00.cms.rcac.purdue.edu
     T2_BR_UERJ:      
       interval: 7
-      server: xrootd.hepgrid.uerj.br
+      server: xrootd2.hepgrid.uerj.br
     T1_ES_PIC_Disk:
       interval: 7
       server: xrootd-cmst1-door.pic.es

--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -56,10 +56,10 @@ consistency:
     T2_DE_RWTH:
       server: grid-cms-xrootd.physik.rwth-aachen.de:1094
       interval: 7
-    T2_FR_GRIF_IRFU:
-      server: node12.datagrid.cea.fr
-      server_root: /cms/trivcat
-      interval: 7
+    #T2_FR_GRIF_IRFU:
+    #  server: node12.datagrid.cea.fr
+    #  server_root: /cms/trivcat
+    #  interval: 7
     #T2_HU_Budapest_Test:
     #  server: grid143.kfki.hu:11000
     #  interval: 1
@@ -78,9 +78,9 @@ consistency:
     T2_IT_Bari:
       server: ss-01.recas.ba.infn.it:8080
       interval: 7
-    T2_FR_GRIF_LLR:
-      server: polgrid4.in2p3.fr:11001
-      interval: 7
+    #T2_FR_GRIF_LLR:
+    #  server: polgrid4.in2p3.fr:11001
+    #  interval: 7
     T2_RU_JINR:
       server: lcgsexrd.jinr.ru:1095
       interval: 7
@@ -228,9 +228,9 @@ consistency:
     T2_EE_Estonia:
       server: xrootd.hep.kbfi.ee:1094
       interval: 7
-    T2_GR_Ioannina:
-      server: grid02.physics.uoi.gr 
-      interval: 7
+    #T2_GR_Ioannina:
+    #  server: grid02.physics.uoi.gr
+    #  interval: 7
     T2_HU_Budapest:
       server: grid143.kfki.hu:11000
       interval: 7


### PR DESCRIPTION
Following up on Eric's suggestion, this removes three likely-retired RSEs (T2_GR_Ioannina , T2_FR_GRIF_LLR and T2_FR_GRIF_IRFU) from the list of consistency jobs which run periodically.  The nodes removed have been on red status for a long time.
