### PR TITLE
Remove prometheus ns to get rid of pods with old naming conventions

### DIFF
--- a/infrastructure/production/kustomization.yaml
+++ b/infrastructure/production/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base/sources
-  - ../base/prometheus
+  # - ../base/prometheus
   - cm-prod-eagle.yaml
   - ../base/kube-eagle
   - ../base/fluentbit


### PR DESCRIPTION
Flux is unable to remove the old pods