### PR TITLE
Revert "update CC tag and jobs, testing monitoring"

### DIFF
--- a/apps/integration/int-consistency-jobs.yaml
+++ b/apps/integration/int-consistency-jobs.yaml
@@ -3,6 +3,13 @@ consistency:
     - /store/test/rucio/int/store/backfill
     - /store/test/rucio/int/store/test
   sites:
-    T2_US_MIT:
-      server: xrootd15.cmsaf.mit.edu:1094
-      interval: 7
+    T2_US_Purdue:      
+      interval: 1
+      server: cms-m001.rcac.purdue.edu
+      server_root:   /store/test/rucio/int/store
+    T2_US_Wisconsin:
+      server: g22n07.hep.wisc.edu:1094
+      interval: 1
+    T2_US_Nebraska:
+      server: red-gridftp10.unl.edu:1094
+      interval: 1

--- a/apps/integration/int-consistency.yaml
+++ b/apps/integration/int-consistency.yaml
@@ -1,10 +1,9 @@
 consistency:
   instance: "int"
   defaultRoot: "/store/test/rucio/int/store"
-  schema: "CMS_RUCIO_INT"
 reportStorageClass:
   osShareID: 635ac65d-f995-43a0-be8c-f502fa4d7b2c
   osShareAccessID: c5d8db3f-4465-4913-8c96-e1613307638d
 image:
   repository: registry.cern.ch/cmsrucio/rucio-consistency
-  tag: release-4.6.1
+  tag: release-4.0.3


### PR DESCRIPTION
Reverts dmwm/rucio-flux#312

Christos said that he doesn't see CC running on int after this change. Reverting now