### PR TITLE
Cleanup cache consumer on integration

### DIFF
--- a/apps/base/rucio-daemons/rucio-daemons-helm.yaml
+++ b/apps/base/rucio-daemons/rucio-daemons-helm.yaml
@@ -40,10 +40,6 @@ spec:
     - kind: Secret
       name: rucio-secrets
       valuesKey: kronos_password
-      targetPath: config.messaging_cache.password
-    - kind: Secret
-      name: rucio-secrets
-      valuesKey: kronos_password
       targetPath: config.trace.password
     - kind: Secret
       name: rucio-secrets

--- a/apps/integration/int-rucio-daemons.yaml
+++ b/apps/integration/int-rucio-daemons.yaml
@@ -3,8 +3,8 @@ conveyorPollerCount: 1
 conveyorFinisherCount: 1
 conveyorPreparerCount: 1
 darkReaperCount: 1
-cacheConsumerCount: 1
 tracerKronosCount: 1
+cacheConsumerCount: 0
 
 reaper:
   includeRses: "cms_type=int"
@@ -12,7 +12,6 @@ reaper:
   threads: 1
 
 darkReaper:
-#  rses: "T2_US_Purdue_Test"
   includeRses: "T2_US_Purdue"
 
 tracerKronos:
@@ -24,42 +23,23 @@ conveyorTransferSubmitter:
 podLabels:
   rucioInstance: "int"
 
-# Move to central
-cacheConsumer:
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
-
 config:
-    common:
-        loglevel: "DEBUG"
-        #loglevel: "INFO"
-    tracer_kronos:
-      brokers: "cms-test-mb.cern.ch"
-      queue: "/topic/cms.rucio.tracer"
-    conveyor:
-      use_preparer: "True"
-      transfertool: "fts3,globus"
-      transfertype: "bulk"
-      scheme: "davs,root,gsiftp,srm,globus"
-      globus_auth_app: "CMSRucioProduction"
-    # Move to central
-    messaging_cache:
-      destination: "/topic/cms.rucio.cache"
-      port: "61313"
-      brokers: "cms-test-mb.cern.ch"
-      ssl_key_file: "/opt/rucio/keys/new_userkey.pem"
-      ssl_cert_file: "/opt/rucio/certs/usercert.pem"
-      reconnect_attempts: "100"
-      use_ssl: "False"
-      username: "cmsrucio"
-    #
-    messaging_hermes:
-      brokers: "cms-test-mb.cern.ch"
-
-
+  common:
+    loglevel: "DEBUG"
+    #loglevel: "INFO"
+  tracer_kronos:
+    brokers: "cms-test-mb.cern.ch"
+    queue: "/topic/cms.rucio.tracer"
+  conveyor:
+    use_preparer: "True"
+    transfertool: "fts3,globus"
+    transfertype: "bulk"
+    scheme: "davs,root,gsiftp,srm,globus"
+    globus_auth_app: "CMSRucioProduction"
+  messaging_hermes:
+    brokers: "cms-test-mb.cern.ch"
 
 conveyorPoller:
-      config:
-        conveyor:
-          transfertool: "fts3"
+  config:
+    conveyor:
+      transfertool: "fts3"


### PR DESCRIPTION
CERN Messaging server reported rucio polling a deleted messaging topic.
```
2024-07-10T10:10:01.685+0200 [ActiveMQ NIO Worker 5] WARN Service - Async error occurred: User cmsrucio is not authorized to read from: topic://cms.rucio.cache
```

We do not use cache RSEs, hence removing the daemon from int.

FYI @ericvaandering 