### PR TITLE
Cleanup cache consumer secret config from prod

### DIFF
--- a/apps/base/rucio-daemons/rucio-daemons-helm.yaml
+++ b/apps/base/rucio-daemons/rucio-daemons-helm.yaml
@@ -12,11 +12,11 @@ spec:
         kind: HelmRepository
         name: rucio
         namespace: flux-system
-#      chart: ./charts/rucio-daemons
-#      sourceRef:
-#        kind: GitRepository
-#        name: rucio-git
-#        namespace: flux-system
+  #      chart: ./charts/rucio-daemons
+  #      sourceRef:
+  #        kind: GitRepository
+  #        name: rucio-git
+  #        namespace: flux-system
   interval: 5m
   install:
     remediation:
@@ -42,10 +42,6 @@ spec:
       name: rucio-secrets
       valuesKey: hermes_password
       targetPath: config.messaging_hermes.password
-    - kind: Secret
-      name: rucio-secrets
-      valuesKey: kronos_password
-      targetPath: config.messaging_cache.password
     - kind: Secret
       name: rucio-secrets
       valuesKey: kronos_password

--- a/apps/integration/int-rucio-daemons.yaml
+++ b/apps/integration/int-rucio-daemons.yaml
@@ -3,7 +3,7 @@ conveyorPollerCount: 1
 conveyorFinisherCount: 1
 conveyorPreparerCount: 1
 darkReaperCount: 1
-cacheConsumerCount: 1
+cacheConsumerCount: 0
 tracerKronosCount: 0
 
 reaper:
@@ -16,12 +16,6 @@ conveyorTransferSubmitter:
 
 podLabels:
   rucioInstance: "int"
-
-# Move to central
-cacheConsumer:
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
 
 config:
   common:
@@ -36,16 +30,6 @@ config:
     transfertype: "bulk"
     scheme: "srm,gsiftp,root,http,https,globus"
     globus_auth_app: "CMSRucioProduction"
-  # Move to central
-  messaging_cache:
-    destination: "/topic/cms.rucio.cache"
-    port: "61313"
-    brokers: "cms-test-mb.cern.ch"
-    ssl_key_file: "/opt/rucio/keys/new_userkey.pem"
-    ssl_cert_file: "/opt/rucio/certs/usercert.pem"
-    reconnect_attempts: "100"
-    use_ssl: "False"
-    username: "cmsrucio"
 
 conveyorPoller:
   config:


### PR DESCRIPTION
Just a cleanup of cache consumer secret from base yaml. 

The actual removal of the daemon is on the `int_globus` branch. 