### PR TITLE
enable drift detection on load test to revert from manual misconfiguration

### DIFF
--- a/apps/options/loadtest/loadtest-helm.yaml
+++ b/apps/options/loadtest/loadtest-helm.yaml
@@ -11,6 +11,10 @@ spec:
         kind: HelmRepository
         name: cms-rucio
         namespace: flux-system
+  driftDetection:
+    mode: enabled
+    ignore:
+      - paths: ["/spec/replicas"]
   interval: 5m
   install:
     remediation:


### PR DESCRIPTION
This will reconcile resources if modified from their state mentioned in git