### PR TITLE
Cleanup create secrets script

### DIFF
--- a/apps/base/rucio-authserver/cms-rucio-authserver.yaml
+++ b/apps/base/rucio-authserver/cms-rucio-authserver.yaml
@@ -18,10 +18,10 @@ httpd_config:
   legacy_dn: "True"
 
 secretMounts:
-  - secretFullName: server-server-hostcert
+  - secretFullName: hostcert
     mountPath: /etc/grid-security/hostcert.pem
     subPath: hostcert.pem
-  - secretFullName: server-server-hostkey
+  - secretFullName: hostkey
     mountPath: /etc/grid-security/hostkey.pem
     subPath: hostkey.pem
   - secretFullName: idpsecrets
@@ -41,7 +41,7 @@ ingress:
   hosts:
     - cms-rucio-auth.cern.ch
   tls:
-    - secretName: rucio-server.tls-secret
+    - secretName: host-tls-secret
 
 useSSL: true
 

--- a/apps/base/rucio-server/cms-rucio-server.yaml
+++ b/apps/base/rucio-server/cms-rucio-server.yaml
@@ -26,7 +26,7 @@ ingress:
   hosts:
     - cms-rucio.cern.ch
   tls:
-    - secretName: rucio-server.tls-secret
+    - secretName: host-tls-secret
 
 useSSL: false
 
@@ -41,9 +41,9 @@ ftsRenewal:
     - name: RUCIO_FTS_SECRETS
       value: "server-rucio-x509up"
   secretMounts:
-    - secretFullName: server-fts-cert
+    - secretFullName: rootcert
       mountPath: /opt/rucio/certs/
-    - secretFullName: server-fts-key
+    - secretFullName: rootkey
       mountPath: /opt/rucio/keys/
 
 serverResources:

--- a/apps/base/rucio-traceserver/cms-rucio-traceserver.yaml
+++ b/apps/base/rucio-traceserver/cms-rucio-traceserver.yaml
@@ -23,8 +23,8 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
   hosts:
     - cms-rucio-trace.cern.ch
-  tls: 
-    - secretName: rucio-server.tls-secret
+  tls:
+    - secretName: host-tls-secret
 
 useSSL: false
 
@@ -36,13 +36,13 @@ serverResources:
 
 config:
   common:
-      loglevel: "INFO"
+    loglevel: "INFO"
   trace:
-      port: "61313"
-      brokers: "cms-mb.cern.ch"
-      topic: "/topic/cms.rucio.tracer"
-      username: "cmsrucio"
-      tracedir: "/var/log/rucio/trace"
+    port: "61313"
+    brokers: "cms-mb.cern.ch"
+    topic: "/topic/cms.rucio.tracer"
+    username: "cmsrucio"
+    tracedir: "/var/log/rucio/trace"
   monitor:
     enable_metrics: "False"
     metrics_port: "8088"

--- a/apps/base/rucio-webui/cms-rucio-webui.yaml
+++ b/apps/base/rucio-webui/cms-rucio-webui.yaml
@@ -22,10 +22,10 @@ httpd_config:
   legacy_dn: "True"
 
 secretMounts:
-  - secretFullName: server-server-hostcert
+  - secretFullName: hostcert
     mountPath: /etc/grid-security/hostcert.pem
     subPath: hostcert.pem
-  - secretFullName: server-server-hostkey
+  - secretFullName: hostkey
     mountPath: /etc/grid-security/hostkey.pem
     subPath: hostkey.pem
 
@@ -36,4 +36,3 @@ persistentVolumes:
 
 optional_config:
   policy_pkg_path: /opt/rucio/policy
-  

--- a/apps/production/prod-loadtest.yaml
+++ b/apps/production/prod-loadtest.yaml
@@ -1,8 +1,8 @@
 loadtest:
   rucioHome: "/opt/rucio-prod/"
-  proxySecret: "daemons-rucio-x509up"
-  sourceExpression:   "loadtest=True"
-  destinationExpression:   "loadtest=True"
+  proxySecret: "server-rucio-x509up"
+  sourceExpression: "loadtest=True"
+  destinationExpression: "loadtest=True"
 
 image:
   repository: registry.cern.ch/cmsrucio/rucio-loadtest-client
@@ -15,6 +15,6 @@ persistentVolumes:
     mountPath: /cvmfs/grid.cern.ch
 
 resources:
-   limits:
-     cpu: 200m
-     memory: 1Gi
+  limits:
+    cpu: 200m
+    memory: 1Gi

--- a/scripts/create_flux_secrets.sh
+++ b/scripts/create_flux_secrets.sh
@@ -5,190 +5,73 @@
 # HOSTP12   - The .p12 file corresponding to the host certificate
 # ROBOTP12  - The .p12 file corresponding to the robot certificate 
 # INSTANCE  - The instance name (dev/testbed/int/prod)
+# UPDATE_HOST_CERTS - Set to 1 to update host certificates
+# UPDATE_FTS_CERTS  - Set to 1 to update FTS certificates
 
-export DAEMON_NAME=daemons
-export SERVER_NAME=server
-export AUTHSERVER_NAME=authserver
-export TRACESERVER_NAME=traceserver
-export UI_NAME=webui
-export GLOBUS_NAME=globus-daemons
-export LOADTEST_NAME=loadtest-daemons
-export TIER0_NAME=tier0-reaper-daemons
+set -euo pipefail
 
-# Maintanance options. Allowing certificate renewal
+# Function to create secrets from .p12 files
+create_secrets_from_p12() {
+    local p12_file=$1
+    local cert_file=$2
+    local key_file=$3
+    local cert_name=$4
+    local key_name=$5
 
-if [ $UPDATE_HOST_CERTS -eq 1 ]; then
-    openssl pkcs12 -in $HOSTP12 -clcerts -nokeys -out ./tls.crt
-    openssl pkcs12 -in $HOSTP12 -nocerts -nodes -out ./tls.key
-    # Secrets for the auth server
-    cp tls.key hostkey.pem
+    openssl pkcs12 -in "$p12_file" -clcerts -nokeys -out "$cert_file"
+    openssl pkcs12 -in "$p12_file" -nocerts -nodes -out "$key_file"
+
+    kubectl -n rucio create secret generic "$cert_name" --from-file="$cert_file" --dry-run=client --save-config -o yaml | kubectl apply -f -
+    kubectl -n rucio create secret generic "$key_name" --from-file="$key_file" --dry-run=client --save-config -o yaml | kubectl apply -f -
+}
+
+# Update host certificates if required
+if [ "${UPDATE_HOST_CERTS:-0}" -eq 1 ]; then
+    create_secrets_from_p12 "$HOSTP12" "tls.crt" "tls.key" "hostcert" "hostkey"
+
     cp tls.crt hostcert.pem
-    kubectl -n rucio create secret generic ${SERVER_NAME}-hostcert --from-file=hostcert.pem --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${SERVER_NAME}-hostkey --from-file=hostkey.pem --dry-run=client --save-config -o yaml | kubectl apply -f -
-
-    kubectl -n rucio create secret generic ${SERVER_NAME}-auth-hostcert --from-file=hostcert.pem --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${SERVER_NAME}-auth-hostkey --from-file=hostkey.pem --dry-run=client --save-config -o yaml | kubectl apply -f -
-
-    export UI_NAME=webui
-    kubectl create -n rucio secret generic ${UI_NAME}-hostcert --from-file=hostcert.pem --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl create -n rucio secret generic ${UI_NAME}-hostkey --from-file=hostkey.pem --dry-run=client --save-config -o yaml | kubectl apply -f -
-    exit 0
-
-elif [ $UPDATE_FTS_CERTS -eq 1 ]; then
-    openssl pkcs12 -in $ROBOTP12 -clcerts -nokeys -out usercert.pem
-    openssl pkcs12 -in $ROBOTP12 -nocerts -nodes -out new_userkey.pem
-
-    export ROBOTCERT=usercert.pem
-    export ROBOTKEY=new_userkey.pem
-    kubectl -n rucio create secret generic ${DAEMON_NAME}-fts-cert --from-file=$ROBOTCERT --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${DAEMON_NAME}-fts-key --from-file=$ROBOTKEY --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${SERVER_NAME}-fts-cert --from-file=$ROBOTCERT --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${SERVER_NAME}-fts-key --from-file=$ROBOTKEY --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${LOADTEST_NAME}-fts-cert --from-file=$ROBOTCERT --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${LOADTEST_NAME}-fts-key --from-file=$ROBOTKEY --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${TIER0_NAME}-fts-cert --from-file=$ROBOTCERT --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${TIER0_NAME}-fts-key --from-file=$ROBOTKEY --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${GLOBUS_NAME}-fts-cert --from-file=$ROBOTCERT --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${GLOBUS_NAME}-fts-key --from-file=$ROBOTKEY --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${DAEMON_NAME}-hermes-cert --from-file=$ROBOTCERT --dry-run=client --save-config -o yaml | kubectl apply -f -
-    kubectl -n rucio create secret generic ${DAEMON_NAME}-hermes-key --from-file=$ROBOTKEY --dry-run=client --save-config -o yaml | kubectl apply -f -
+    cp tls.key hostkey.pem
+    kubectl -n rucio create secret tls host-tls-secret --key=tls.key --cert=tls.crt --dry-run=client --save-config -o yaml | kubectl apply -f -
     exit 0
 fi
 
-echo
+# Update FTS certificates if required
+if [ "${UPDATE_FTS_CERTS:-0}" -eq 1 ]; then
+    create_secrets_from_p12 "$ROBOTP12" "robotcert.pem" "robotkey.pem" "rootcert" "rootkey"
+    exit 0
+fi
+
+# Create the namespace if it doesn't exist
+kubectl create namespace rucio --dry-run=client -o yaml | kubectl apply -f -
+
+# Extract certificates and keys from the .p12 files
 echo "When prompted, enter the password used to encrypt the HOST P12 file"
+openssl pkcs12 -in "$HOSTP12" -clcerts -nokeys -out tls.crt
+openssl pkcs12 -in "$HOSTP12" -nocerts -nodes -out tls.key
 
-# Setup files so that secrets are unavailable the least amount of time
-
-openssl pkcs12 -in $HOSTP12 -clcerts -nokeys -out ./tls.crt
-openssl pkcs12 -in $HOSTP12 -nocerts -nodes -out ./tls.key
-# Secrets for the auth server
 cp tls.key hostkey.pem
 cp tls.crt hostcert.pem
-cp /etc/pki/tls/certs/CERN_Root_CA.pem ca.pem
-chmod 600 ca.pem
 
-
-echo
 echo "When prompted, enter the password used to encrypt the ROBOT P12 file"
+openssl pkcs12 -in "$ROBOTP12" -clcerts -nokeys -out robotcert.pem
+openssl pkcs12 -in "$ROBOTP12" -nocerts -nodes -out robotkey.pem
 
-openssl pkcs12 -in $ROBOTP12 -clcerts -nokeys -out usercert.pem
-openssl pkcs12 -in $ROBOTP12 -nocerts -nodes -out new_userkey.pem
-
-export ROBOTCERT=usercert.pem
-export ROBOTKEY=new_userkey.pem
-
-
-kubectl create namespace rucio
-
-# Many of these are old names. Change as we slowly adopt the new names everywhere.
-
-echo "Removing existing secrets"
-
-kubectl -n rucio delete secret rucio-server.tls-secret
-kubectl -n rucio delete secret ${DAEMON_NAME}-fts-cert ${DAEMON_NAME}-fts-key ${DAEMON_NAME}-hermes-cert ${DAEMON_NAME}-hermes-key 
-kubectl -n rucio delete secret ${SERVER_NAME}-fts-cert ${SERVER_NAME}-fts-key
-kubectl -n rucio delete secret ${LOADTEST_NAME}-fts-cert ${LOADTEST_NAME}-fts-key
-kubectl -n rucio delete secret ${TIER0_NAME}-fts-cert ${TIER0_NAME}-fts-key
-kubectl -n rucio delete secret ${DAEMON_NAME}-rucio-ca-bundle ${DAEMON_NAME}-rucio-ca-bundle-reaper
-kubectl -n rucio delete secret ${GLOBUS_NAME}-rucio-ca-bundle ${GLOBUS_NAME}-rucio-ca-bundle-reaper
-kubectl -n rucio delete secret ${LOADTEST_NAME}-rucio-ca-bundle ${LOADTEST_NAME}-rucio-ca-bundle-reaper
-kubectl -n rucio delete secret ${TIER0_NAME}-rucio-ca-bundle-reaper
-kubectl -n rucio delete secret ${SERVER_NAME}-rucio-ca-bundle
-kubectl -n rucio delete secret ${SERVER_NAME}-hostcert ${SERVER_NAME}-hostkey ${SERVER_NAME}-cafile  
-kubectl -n rucio delete secret ${AUTHSERVER_NAME}-hostcert ${AUTHSERVER_NAME}-hostkey ${AUTHSERVER_NAME}-cafile
-kubectl -n rucio delete secret ${TRACESERVER_NAME}-hostcert ${TRACESERVER_NAME}-hostkey ${TRACESERVER_NAME}-cafile
-kubectl -n rucio delete secret ${SERVER_NAME}-auth-hostcert ${SERVER_NAME}-auth-hostkey ${SERVER_NAME}-auth-cafile
-kubectl -n rucio delete secret ${UI_NAME}-hostcert ${UI_NAME}-hostkey ${UI_NAME}-cafile 
-kubectl -n rucio delete secret ${LOADTEST_NAME}-rucio-x509up
-kubectl -n rucio delete secret ${TIER0_NAME}-rucio-x509up
-kubectl -n rucio delete secret ${SERVER_NAME}-server-hostcert ${SERVER_NAME}-server-hostkey ${SERVER_NAME}-server-cafile  --from-file=ca.pem
-
-# cms-ruciod-prod-rucio-x509up is created by the FTS key generator
-
+# Create new secrets
 echo "Creating new secrets"
-kubectl -n rucio create secret tls rucio-server.tls-secret --key=tls.key --cert=tls.crt
+kubectl -n rucio create secret tls host-tls-secret --key=tls.key --cert=tls.crt
+kubectl -n rucio create secret generic rootcert --from-file=robotcert.pem
+kubectl -n rucio create secret generic rootkey --from-file=robotkey.pem
+kubectl -n rucio create secret generic hostcert --from-file=hostcert.pem
+kubectl -n rucio create secret generic hostkey --from-file=hostkey.pem
 
-kubectl -n rucio create secret generic ${SERVER_NAME}-server-hostcert --from-file=hostcert.pem
-kubectl -n rucio create secret generic ${SERVER_NAME}-server-hostkey --from-file=hostkey.pem
-kubectl -n rucio create secret generic ${SERVER_NAME}-server-cafile  --from-file=ca.pem
-kubectl -n rucio create secret generic ${AUTHSERVER_NAME}-server-hostcert --from-file=hostcert.pem
-kubectl -n rucio create secret generic ${AUTHSERVER_NAME}-server-hostkey --from-file=hostkey.pem
-kubectl -n rucio create secret generic ${AUTHSERVER_NAME}-server-cafile  --from-file=ca.pem
-kubectl -n rucio create secret generic ${TRACESERVER_NAME}-server-hostcert --from-file=hostcert.pem
-kubectl -n rucio create secret generic ${TRACESERVER_NAME}-server-hostkey --from-file=hostkey.pem
-kubectl -n rucio create secret generic ${TRACESERVER_NAME}-server-cafile  --from-file=ca.pem
+# Create a dummy secret - replace with the actual proxy as needed
+kubectl -n rucio create secret generic server-rucio-x509up --from-file=/etc/pki/tls/certs/CERN-bundle.pem 
 
-# Make secrets for WEBUI
-# We don't make the CA file here, but lower because it is different than the regular server
+# Clean up temporary files
+rm tls.key tls.crt hostkey.pem hostcert.pem robotcert.pem robotkey.pem
 
-export UI_NAME=webui
-kubectl create -n rucio secret generic ${UI_NAME}-hostcert --from-file=hostcert.pem
-kubectl create -n rucio secret generic ${UI_NAME}-hostkey --from-file=hostkey.pem
+# Create secrets from an environment file
+kubectl -n rucio create secret generic rucio-secrets --from-env-file="${INSTANCE}-secrets.yaml"
 
-# Secrets for FTS, hermes
-
-kubectl -n rucio create secret generic ${DAEMON_NAME}-fts-cert --from-file=$ROBOTCERT
-kubectl -n rucio create secret generic ${DAEMON_NAME}-fts-key --from-file=$ROBOTKEY
-kubectl -n rucio create secret generic ${SERVER_NAME}-fts-cert --from-file=$ROBOTCERT
-kubectl -n rucio create secret generic ${SERVER_NAME}-fts-key --from-file=$ROBOTKEY
-kubectl -n rucio create secret generic ${LOADTEST_NAME}-fts-cert --from-file=$ROBOTCERT
-kubectl -n rucio create secret generic ${LOADTEST_NAME}-fts-key --from-file=$ROBOTKEY
-kubectl -n rucio create secret generic ${TIER0_NAME}-fts-cert --from-file=$ROBOTCERT
-kubectl -n rucio create secret generic ${TIER0_NAME}-fts-key --from-file=$ROBOTKEY
-kubectl -n rucio create secret generic ${DAEMON_NAME}-hermes-cert --from-file=$ROBOTCERT
-kubectl -n rucio create secret generic ${DAEMON_NAME}-hermes-key --from-file=$ROBOTKEY
-kubectl -n rucio create secret generic ${DAEMON_NAME}-rucio-ca-bundle --from-file=/etc/pki/tls/certs/CERN-bundle.pem
-
-# Secrets for Globus
-kubectl -n rucio create secret generic ${GLOBUS_NAME}-rucio-ca-bundle --from-file=/etc/pki/tls/certs/CERN-bundle.pem
-kubectl -n rucio delete secret ${GLOBUS_NAME}-rucio-x509up
-kubectl -n rucio create secret generic ${GLOBUS_NAME}-rucio-x509up  --from-file=/etc/pki/tls/certs/CERN-bundle.pem # This is a dummy, but needed for container to start
-kubectl -n rucio create secret generic ${GLOBUS_NAME}-fts-cert --from-file=$ROBOTCERT
-kubectl -n rucio create secret generic ${GLOBUS_NAME}-fts-key --from-file=$ROBOTKEY
-
-# Secrets for Load test
-kubectl create -n rucio secret generic ${LOADTEST_NAME}-rucio-ca-bundle --from-file=/etc/pki/tls/certs/CERN-bundle.pem
-kubectl create -n rucio secret generic ${LOADTEST_NAME}-rucio-x509up  --from-file=/etc/pki/tls/certs/CERN-bundle.pem # This is a dummy, but needed for container to start
-
-# Secrets for Tier0 Reaper
-kubectl create -n rucio secret generic ${TIER0_NAME}-rucio-ca-bundle --from-file=/etc/pki/tls/certs/CERN-bundle.pem
-kubectl create -n rucio secret generic ${TIER0_NAME}-rucio-x509up  --from-file=/etc/pki/tls/certs/CERN-bundle.pem # This is a dummy, but needed for container to start
-
-# More secrets for server
-kubectl create -n rucio secret generic ${SERVER_NAME}-rucio-ca-bundle --from-file=/etc/pki/tls/certs/CERN-bundle.pem
-kubectl create -n rucio secret generic ${AUTHSERVER_NAME}-rucio-ca-bundle --from-file=/etc/pki/tls/certs/CERN-bundle.pem
-kubectl create -n rucio secret generic ${TRACESERVER_NAME}-rucio-ca-bundle --from-file=/etc/pki/tls/certs/CERN-bundle.pem
-kubectl create -n rucio secret generic ${SERVER_NAME}-rucio-x509up  --from-file=/etc/pki/tls/certs/CERN-bundle.pem # This is a dummy, but needed for container to start
-kubectl create -n rucio secret generic ${AUTHSERVER_NAME}-rucio-x509up  --from-file=/etc/pki/tls/certs/CERN-bundle.pem # This is a dummy, but needed for container to start
-kubectl create -n rucio secret generic ${TRACESERVER_NAME}-rucio-x509up  --from-file=/etc/pki/tls/certs/CERN-bundle.pem # This is a dummy, but needed for container to start
-kubectl create -n rucio secret generic ${DAEMON_NAME}-rucio-x509up  --from-file=/etc/pki/tls/certs/CERN-bundle.pem # This is a dummy, but needed for container to start
-
-# WebUI needs whole bundle as ca.pem. Keep this at end since we just over-wrote ca.pem
-
-cp /etc/pki/tls/certs/CERN-bundle.pem ca.pem  
-kubectl -n rucio create secret generic ${UI_NAME}-cafile  --from-file=ca.pem
-
-# Temp sp we can run old version too
-
-kubectl -n rucio create secret generic ${SERVER_NAME}-auth-hostcert --from-file=hostcert.pem
-kubectl -n rucio create secret generic ${SERVER_NAME}-auth-hostkey --from-file=hostkey.pem
-kubectl -n rucio create secret generic ${SERVER_NAME}-auth-cafile  --from-file=ca.pem
-
-
-# Clean up
-rm tls.key tls.crt hostkey.pem hostcert.pem ca.pem
-rm usercert.pem new_userkey.pem
-
-# Reapers needs the whole directory of certificates
-mkdir /tmp/reaper-certs
-cp /etc/grid-security/certificates/*.0 /tmp/reaper-certs/
-cp /etc/grid-security/certificates/*.signing_policy /tmp/reaper-certs/
-kubectl -n rucio create secret generic ${DAEMON_NAME}-rucio-ca-bundle-reaper --from-file=/tmp/reaper-certs/
-kubectl -n rucio create secret generic ${GLOBUS_NAME}-rucio-ca-bundle-reaper --from-file=/tmp/reaper-certs/
-kubectl -n rucio create secret generic ${TIER0_NAME}-rucio-ca-bundle-reaper --from-file=/tmp/reaper-certs/
-rm -rf /tmp/reaper-certs
-
-kubectl -n rucio create secret generic rucio-secrets --from-env-file=${INSTANCE}-secrets.yaml
-
+# Display the created secrets
 kubectl -n rucio get secrets


### PR DESCRIPTION
We are left with 3 secrets as of now

**1. HOST cert/key**
- renamed to `hostcert` and `hostkey` from `server-server-hostcert` and `server-server-hostkey` respectively.

**2. ROBOT cert/key**
- renamed to `rootcert` and `rootkey` from `server-fts-cert` and `server-fts-key` respectively.

**3. TLS secrets**
- same as host cert but with `.crt` file extension for the cert to create a secret object of TLS type.