### PR TITLE
Deploy throttler in prod

### DIFF
--- a/apps/base/rucio-daemons/cms-rucio-daemons.yaml
+++ b/apps/base/rucio-daemons/cms-rucio-daemons.yaml
@@ -4,6 +4,7 @@ image:
 abacusAccountCount: 1
 abacusRseCount: 1
 conveyorPreparerCount: 3
+conveyorThrottlerCount: 2
 conveyorTransferSubmitterCount: 3
 conveyorPollerCount: 2
 conveyorFinisherCount: 2


### PR DESCRIPTION
I made its count the same as the poller and the finisher. It's not a heavy process, I expect it should be fine.

Once it's deployed, I'll throttle transfers to CNAF.

@Panos512 fyi