### PR TITLE
Move throttler config from base to prod file

### DIFF
--- a/apps/base/rucio-daemons/cms-rucio-daemons.yaml
+++ b/apps/base/rucio-daemons/cms-rucio-daemons.yaml
@@ -4,7 +4,6 @@ image:
 abacusAccountCount: 1
 abacusRseCount: 1
 conveyorPreparerCount: 3
-conveyorThrottlerCount: 2
 conveyorTransferSubmitterCount: 3
 conveyorPollerCount: 2
 conveyorFinisherCount: 2

--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -6,6 +6,7 @@ conveyorTransferSubmitterCount: 3
 conveyorPollerCount: 4
 conveyorReceiverCount: 1
 conveyorFinisherCount: 4
+conveyorThrottlerCount: 2
 
 judgeEvaluatorCount: 2
 tracerKronosCount: 3


### PR DESCRIPTION
https://github.com/dmwm/rucio-flux/pull/325 introduced 4 extra pods since it's defined in the base config and loadtest and tier0-reaper inherit the base. 
```
$ k get pods | grep throttler
daemons-conveyor-throttler-58b5df5764-m4tv6                1/1     Running     0               11h
daemons-conveyor-throttler-58b5df5764-v6cbp                1/1     Running     0               11h
loadtest-daemons-conveyor-throttler-57fffd75f7-92ntn       1/1     Running     0               8d
loadtest-daemons-conveyor-throttler-57fffd75f7-z94ks       1/1     Running     0               8d
tier0-reaper-daemons-conveyor-throttler-6fc75f6cc6-gh2fc   1/1     Running     0               8d
tier0-reaper-daemons-conveyor-throttler-6fc75f6cc6-tz4jg   1/1     Running     0               8d
```
I moved it to the prod file. The other conveyor counts are defined both in base and prod and their counts are explicitly set to 0 in loadtest and tier0-reaper configs. I fail to see the point of this. @dynamic-entropy let me know how this PR looks. If there's a problem with it, I can do it the "old" way and define it in base and prod and explicitly set its counts to 0 for loadtest and tier0-reaper. I just need to know why if that's necessary.
