### PR TITLE
Activate replica recoverer

### DIFF
--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -15,7 +15,7 @@ replicaRecovererCount: 1
 minosTemporaryExpirationCount: 1
 
 replicaRecoverer:
-  activeMode: false
+  activeMode: true
   secretMounts:
     - secretFullName: replica-recoverer-config
       mountPath: /opt/rucio/etc/suspicious_replica_recoverer.json


### PR DESCRIPTION
After configuring the daemon, looking at the logs; it seems to be acting as expected, e.g.
```
{"process": {"pid": 9}, "log": {"logger": "root", "level": "INFO"}, "@timestamp": "2024-09-23T11:54:12.609Z", "message": "[5/11]: Declare bad: RSE: T2_US_Caltech    Scope: cms    Name: /store/mc/Run3Summer23NanoAODv12/WtoLNu-2Jets_PTLNu-100to200_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/NANOAODSIM/130X_mcRun3_2023_realistic_v14-v3/40000/d27e772e-fb70-418a-9b91-29102b57aeec.root    Datatype: None    PFN: davs://k8s-redir-stageout.ultralight.org:1094/store/mc/Run3Summer23NanoAODv12/WtoLNu-2Jets_PTLNu-100to200_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/NANOAODSIM/130X_mcRun3_2023_realistic_v14-v3/40000/d27e772e-fb70-418a-9b91-29102b57aeec.root", "error": {"type": null, "message": null, "stack_trace": null}}
```

Currently the daemon is enabled only on one RSE: T2_US_Caltech. We can activate it at this point, so that it can start declaring replicas bad if they are declared suspicious enough times OR create rules to see if they are really corrupt. I'll monitor how it behaves on Caltech and include other RSEs later on if everything goes as expected.
