### PR TITLE
use --ignore-availability for preparer

### DIFF
--- a/apps/base/rucio-daemons/cms-rucio-daemons.yaml
+++ b/apps/base/rucio-daemons/cms-rucio-daemons.yaml
@@ -100,6 +100,7 @@ conveyorPreparer:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
   threads: 5
+  ignoreAvailability: true
 
 conveyorFinisher:
   podAnnotations:


### PR DESCRIPTION
Since https://github.com/rucio/helm-charts/pull/210 was merged, `--ignore-availability` can be used for preparer. In similar way, it is used for loadtest submitter :

https://github.com/dmwm/rucio-flux/blob/c0f8980b3463b86cae88018d6a27023eb2242d68/apps/production/loadtest-rucio-daemons.yaml#L26-L31

Doing that, [CMSTRANSF-994](https://its.cern.ch/jira/browse/CMSTRANSF-994) will be solved.