### PR TITLE
Test consistency prometheus

### DIFF
--- a/apps/base/cms-rucio-consistency/cms-consistency-helm.yaml
+++ b/apps/base/cms-rucio-consistency/cms-consistency-helm.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: helm/rucio-consistency
-      version: 3.2.0
+      version: 3.3.1
       sourceRef:
         kind: HelmRepository
         name: cms-rucio-oci

--- a/apps/integration/int-consistency.yaml
+++ b/apps/integration/int-consistency.yaml
@@ -2,9 +2,17 @@ consistency:
   instance: "int"
   defaultRoot: "/store/test/rucio/int/store"
   schema: "CMS_RUCIO_INT"
+  prometheus_servers: "prometheus-prometheus-pushgateway.prometheus:9091"
+  prometheus_prefix: "rucio_int_"
+  prometheus_labels: ""
+  rucio_host: "http://cms-rucio-int.cern.ch"
+  auth_host: "https://cms-rucio-auth-int.cern.ch"
+  auth_type: "x509_proxy"
+  ca_cert: "/etc/grid-security/certificates/"
+  request_retries: "3"
 reportStorageClass:
   osShareID: 8fdf6903-e97d-4733-a377-b374205355bc
   osShareAccessID: 4eba641d-6a38-4e88-8e4b-b127e6c92867 
 image:
   repository: registry.cern.ch/cmsrucio/rucio-consistency
-  tag: release-4.6.1
+  tag: release-4.7.0


### PR DESCRIPTION
Related to https://github.com/dmwm/CMSRucio/issues/755

The first steps taken towards achieving the desired are:
- Providing CC the way to push metrics to prometheus
  - https://github.com/dmwm/cms_consistency/pull/6
  - https://github.com/dmwm/cms_consistency/releases/tag/release-4.6.1
- Updating flux to test changes in integration
  - https://github.com/dmwm/rucio-flux/commit/dfdd920e0f55b9074e0669cec6da5facfdc331ba

Although, CC was not able to read the desired configurations and thus more changes were needed. This PR wants to test the following additional changes in integration:
- https://github.com/dmwm/cms_consistency/pull/8
   - https://github.com/dmwm/cms_consistency/releases/tag/release-4.7.0
- https://github.com/dmwm/CMSRucio/pull/844

It is noted that, since the changes made in the helm chart are not in the main branch, the charts was pushed in a different registry compared to the registry usually being used and so the updated helm chart used in this PR is pulled from this different registry.