### PR TITLE
Increase memory limit of replica recoverer

### DIFF
--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -21,6 +21,11 @@ replicaRecoverer:
     - secretFullName: replica-recoverer-config
       mountPath: /opt/rucio/etc/suspicious_replica_recoverer.json
       subPath: suspicious_replica_recoverer.json
+    resources:
+      limits:
+        memory: 1Gi
+      requests:
+        memory: 400Mi
 
 reaper:
   includeRses: "reaper=True"


### PR DESCRIPTION
It's crashing with 200Mi limit:
```
$ k describe pod daemons-replica-recoverer-84696bd6c4-x54gb | grep -B 3 -A 3 OOM
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Wed, 16 Oct 2024 14:34:15 +0200
      Finished:     Wed, 16 Oct 2024 14:34:40 +0200
```
Not sure, if 1Gi will be enough, but I think it's a reasonable limit to try out. Looks like we can afford it:
```
$ k top nodes
NAME                                  CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
cmsrucioprod2-yfehlu7mkan2-master-0   353m         4%     8883Mi          63%       
cmsrucioprod2-yfehlu7mkan2-node-0     1111m        13%    5745Mi          40%       
cmsrucioprod2-yfehlu7mkan2-node-1     2511m        31%    8073Mi          57%       
cmsrucioprod2-yfehlu7mkan2-node-2     941m         11%    10151Mi         72%       
cmsrucioprod2-yfehlu7mkan2-node-3     1982m        24%    8134Mi          57%       
cmsrucioprod2-yfehlu7mkan2-node-4     332m         4%     8771Mi          62%       
cmsrucioprod2-yfehlu7mkan2-node-5     2137m        26%    7117Mi          50%       
cmsrucioprod2-yfehlu7mkan2-node-6     710m         8%     7430Mi          52%       
cmsrucioprod2-yfehlu7mkan2-node-7     1333m        16%    9990Mi          71%  
```