### PR TITLE
Make log level of throttler DEBUG

### DIFF
--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -64,6 +64,11 @@ conveyorFinisher:
     requests:
       memory: 400Mi
 
+conveyorThrottler:
+  config:
+    common:
+      loglevel: "DEBUG"
+
 podLabels:
   rucioInstance: "prod"
 


### PR DESCRIPTION
Meaningful logs are in debug level: https://github.com/rucio/rucio/blob/master/lib/rucio/daemons/conveyor/throttler.py#L375 