### PR TITLE
Override the archive-timeout to 1 hour as opposed to not setting it.

### DIFF
--- a/apps/production/loadtest-rucio-daemons.yaml
+++ b/apps/production/loadtest-rucio-daemons.yaml
@@ -26,7 +26,7 @@ minosTemporaryExpirationCount: 0
 conveyorTransferSubmitter:
   activities: "'Functional Test'"
   groupBulk: 10
-  archiveTimeout: 0
+  archiveTimeout: 3600
   ignoreAvailability: true
   threads: 1
 


### PR DESCRIPTION
A valid tape transfer should always contain a archive-timeout field in the parameters.

With the introduction of `overwrite-when-only-on-disk` flag, FTS introduced many other strict flag checks.