### PR TITLE
Revert "Deploy patch 7199"

### DIFF
--- a/apps/production/prod-release.yaml
+++ b/apps/production/prod-release.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: release-35.4.0.cms6
+  tag: release-35.4.0.cms4
 
 # FIXME: Maybe not the best place for this but everything may need it
 config:


### PR DESCRIPTION
Reverts dmwm/rucio-flux#358 due to 
```
Hunk #1 succeeded at 43 (offset -2 lines).
Hunk #2 succeeded at 139 (offset -2 lines).
Hunk #3 succeeded at 220 (offset -2 lines).
Hunk #4 succeeded at 467 (offset -2 lines).
Hunk #5 succeeded at 652 (offset -2 lines).
Hunk #6 succeeded at 669 (offset -2 lines).
Patch /patch/7199.patch/lib applied.
Applying patch /patch/token.patch
patching file core/oidc.py
patching file core/rse.py
patching file daemons/reaper/reaper.py
Hunk #1 FAILED at 44.
Hunk #2 succeeded at 642 (offset 25 lines).
1 out of 2 hunks FAILED -- saving rejects to file daemons/reaper/reaper.py.rej
patching file transfertool/fts3.py
Patch /patch/token.patch/lib could not be applied successfully (exit code 1). Exiting setup.
```