### PR TITLE
Remove server, server_root and other CE config parameters

### DIFF
--- a/apps/production/prod-consistency-jobs.yaml
+++ b/apps/production/prod-consistency-jobs.yaml
@@ -11,50 +11,32 @@ consistency:
   sites:
     T1_DE_KIT_Disk:
       interval: 7
-      server: cmsxrootd-kit-disk.gridka.de:1094
-      server_root: /
-      timeout: 3600
     T1_DE_KIT_Tape:
       interval: 7
-      server: cmsxrootd-kit-tape.gridka.de:1094
-      server_root: /
-      timeout: 3600
     T2_US_Purdue:
       interval: 7
-      server: af-a00.cms.rcac.purdue.edu
     T2_BR_UERJ:
       interval: 7
-      server: xrootd2.hepgrid.uerj.br
     T1_ES_PIC_Disk:
       interval: 7
-      server: xrootd-cmst1-door.pic.es
     T1_UK_RAL_Tape:
       interval: 0
       maxdarkfraction: "0.0000001"
     T1_US_FNAL_Disk:
       interval: 7
-      server: cmsdcadisk.fnal.gov
-      server_root: /dcache/uscmsdisk
-      maxdarkfraction: 0.05
-      maxmissfraction: 0.02
     T2_TW_NCHC:
-      server: se01.grid.nchc.org.tw:11001
       interval: 7
     #T2_UK_London_IC_Test:
     #  server: gfe02.grid.hep.ph.ic.ac.uk:1095
     #  interval: 1
     T2_ES_CIEMAT:
-      server: gaexroot01.ciemat.es:1095
       interval: 7
     #T2_PT_NCG_Lisbon_Test:
     #  server: xroot-data02.ncg.ingrid.pt:1094
     #  interval: 1
     T2_UK_SGrid_Bristol:
-      server: xrootd.phy.bris.ac.uk:1094
-      server_root: /xrootd/cms
       interval: 7
     T2_DE_RWTH:
-      server: grid-cms-xrootd.physik.rwth-aachen.de:1094
       interval: 7
     #T2_HU_Budapest_Test:
     #  server: grid143.kfki.hu:11000
@@ -63,7 +45,6 @@ consistency:
     #  server: xrd-ds06.sprace.org.br:1094
     #  interval: 1
     T2_RU_IHEP:
-      server: dp0015.m45.ihep.su:1094
       interval: 7
     #T2_TR_METU_Test:
     #  server: eymir.grid.metu.edu.tr:11001
@@ -72,38 +53,28 @@ consistency:
     #  server: gftp-1.t2.ucsd.edu:1094
     #  interval: 1
     T2_IT_Bari:
-      server: ss-01.recas.ba.infn.it:8080
       interval: 7
     T2_RU_JINR:
-      server: lcgsexrd.jinr.ru:1095
       interval: 7
     T2_IT_Pisa:
-      server: stormgf2.pi.infn.it:1094
       interval: 7
     T2_FI_HIP:
-      server: nute.csc.fi:1094
       interval: 7
     T2_IT_Legnaro:
-      server: t2-xrdcms.lnl.infn.it:7070
-      # server: "193.206.93.80:1094"
       interval: 7
     #T3_TW_NTU_HEP_Test:
     #  server: ntugrid6.phys.ntu.edu.tw:11000
     #  interval: 1
     T2_BE_IIHE:
-      server: maite.iihe.ac.be:1095
       interval: 7
     T2_PL_Swierk:
-      server: se.cis.gov.pl:11000
       interval: 7
     #T2_EE_Estonia_Test:
     #server: [2001:bb8:4004:ff:d::3]:1094
     #interval: 1
     T2_UK_SGrid_RALPP:
-      server: heplnx228.pp.rl.ac.uk:1094
       interval: 7
     T2_US_Wisconsin:
-      server: pubxrootd.hep.wisc.edu:1094
       interval: 7
     #T2_CN_Beijing_Test:
     #  server: seadmin.ihep.ac.cn:1094
@@ -117,13 +88,11 @@ consistency:
     #  #server: cmsio7.rc.ufl.edu:1094
     #  interval: 1
     T2_IT_Rome:
-      server: cmsrm-xrootd02.roma1.infn.it:7070
       interval: 7
     #T2_GR_Ioannina_Test:
     #  server: grid02.physics.uoi.gr:11001
     #  interval: 1
     T2_PK_NCP:
-      server: pcncp22.ncp.edu.pk:11001
       interval: 7
     #T3_CH_PSI_Test:
     #  server: t3se01.psi.ch
@@ -141,24 +110,17 @@ consistency:
     #  #server: xrootd-srv.accre.vanderbilt.edu:1094
     #  interval: 1
     T2_RU_INR:
-      server: grse001.inr.troitsk.ru:11000
       interval: 7
     #T2_RU_ITEP_Test:
     #  server: se3.itep.ru:1095
     #  interval: 1
     T2_IN_TIFR:
-      server: se01.indiacms.res.in:11001
       interval: 7
     T2_CH_CSCS:
-      server: storage01.lcg.cscs.ch:1096
-      server_root: /pnfs/lcg.cscs.ch/cms/trivcat
       interval: 7
     T2_FR_IPHC:
-      server: sbgse1.in2p3.fr:1094
-      server_root: /cms/phedex
       interval: 7
     T2_AT_Vienna:
-      server: eos.grid.vbc.ac.at:1094
       interval: 7
     #T2_ES_IFCA_Test:
     #  server: pool04.ifca.es:1094
@@ -174,7 +136,6 @@ consistency:
     #  server: eoscms.cern.ch:1094
     #  interval: 1
     T2_KR_KISTI:
-      server: cms-t2-se01.sdfarm.kr:1095
       interval: 7
     #T2_UA_KIPT_Test:
     #  server: cms-se0.kipt.kharkov.ua:11001
@@ -202,69 +163,44 @@ consistency:
     #  server: se01.grid.nchc.org.tw:11001
     #  interval: 1
     T3_US_Rutgers:
-      server: ruhex-osgce.rutgers.edu
       interval: 7
     T1_IT_CNAF_Disk:
-      server: xrootd-cms.cr.cnaf.infn.it
       interval: 7
     T2_BR_SPRACE:
-      server: osg-se.sprace.org.br
       interval: 7
     T2_CN_Beijing:
-      server: ccsrm.ihep.ac.cn:1094
-      server_root: /cms
       interval: 7
     T2_DE_DESY:
-      server: t2-cms-xrootd01.desy.de:1094
       interval: 7
-      maxmissfraction: 0.03
     T2_EE_Estonia:
-      server: xrootd.hep.kbfi.ee:1094
       interval: 7
     T2_HU_Budapest:
-      server: grid143.kfki.hu:11000
       interval: 7
     T2_PT_NCG_Lisbon:
-      server: xroot02.ncg.ingrid.pt:1094
       interval: 7
     T2_TR_METU:
-      server: eymir.grid.metu.edu.tr
-      server_root: /cms
       interval: 7
     T2_UA_KIPT:
-      server: cms-se0.kipt.kharkov.ua:11001
       interval: 7
     T2_UK_London_Brunel:
-      server: dc2-grid-64.brunel.ac.uk:1094
-      server_root: /dpm/brunel.ac.uk/home/cms
       interval: 7
     T2_US_Caltech:
-      server: transfer-1.ultralight.org
       interval: 7
     T2_US_Florida:
-      server: cmsio2.rc.ufl.edu
       interval: 7
     T2_US_MIT:
-      server: xrootd15.cmsaf.mit.edu:1094
       interval: 7
     T2_US_Nebraska:
-      server: xrootd-local.unl.edu:1094
       interval: 7
     T2_US_UCSD:
-      server: redirector.t2.ucsd.edu:1095
       interval: 7
     T2_US_Vanderbilt:
-      server: xrootd-vanderbilt.sites.opensciencegrid.org
       interval: 7
     T2_CH_CERN:
-      server: eoscms.cern.ch
-      server_root: /eos/cms
       interval: 7
     T0_CH_CERN_Disk:
-      server: eoscms.cern.ch
-      server_root: /eos/cms/tier0
       interval: 7
-    # T1_FR_CCIN2P3_Tape:
+    #T1_FR_CCIN2P3_Tape:
     #   server: ccxrootdcms.in2p3.fr:1094
     #   server_root: /pnfs/in2p3.fr/data/cms/data
     #   interval: 7
@@ -273,22 +209,14 @@ consistency:
     #  server_root: /pnfs/in2p3.fr/data/cms/disk/data
     #  interval: 7
     T1_RU_JINR_Disk:
-      server: xrootd01.jinr-t1.ru:1094
-      server_root: /pnfs/jinr-t1.ru/data/cms
       interval: 7
     T2_BE_UCL:
-      server: ingrid-se08.cism.ucl.ac.be:1094
       interval: 7
     T2_ES_IFCA:
-      server: gridftp.ifca.es
       interval: 7
     T2_RU_ITEP:
-      server: se3.itep.ru
       interval: 7
     T2_UK_London_IC:
-      server: gfe02.grid.hep.ph.ic.ac.uk:1094
-      server_root: /pnfs/hep.ph.ic.ac.uk/data/cms
       interval: 7
     T3_KR_UOS:
-      server: cms.sscc.uos.ac.kr:1094
       interval: 7


### PR DESCRIPTION
All removed parameters are now defined as RSE attributes, so they are not needed here.
