### PR TITLE
Increase receiver count, lower poller count

### DIFF
--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -3,8 +3,8 @@ reaperCount: 8
 judgeInjectorCount: 2
 judgeRepairerCount: 2
 conveyorTransferSubmitterCount: 3
-conveyorPollerCount: 8
-conveyorReceiverCount: 1
+conveyorPollerCount: 4
+conveyorReceiverCount: 8
 conveyorFinisherCount: 4
 conveyorThrottlerCount: 1
 


### PR DESCRIPTION
The problem described https://github.com/dmwm/rucio-flux/pull/373 wasn't fixed by increasing the poller count. Looks like receiver is the one marking requests as Done or Failed. I'm bumping up its count. Transfers of this rule is waiting to be marked as Done for 1 week now: https://cms-rucio-webui.cern.ch/rule?rule_id=82b090ed1b4641afa1ddf63535fc34ee#locks 

@ericvaandering fyi