### PR TITLE
Increase the log level of poller

### DIFF
--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -45,6 +45,9 @@ conveyorPoller:
     requests:
       cpu: 750m
       memory: 400Mi
+  config:
+    common:
+      loglevel: "DEBUG"
 
 judgeEvaluator:
   threads: 8


### PR DESCRIPTION
Debugging the transfer whose external_id is `9fffe8cc-ed1c-11ef-9b17-724719a633f9`. It was last processed by poller today. Although the transfer is finished, it wasn't marked as done. Trying to figure out why.