### PR TITLE
Decrease logging level of poller and receiver count

### DIFF
--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -4,7 +4,7 @@ judgeInjectorCount: 2
 judgeRepairerCount: 2
 conveyorTransferSubmitterCount: 3
 conveyorPollerCount: 4
-conveyorReceiverCount: 8
+conveyorReceiverCount: 2
 conveyorFinisherCount: 4
 conveyorThrottlerCount: 1
 
@@ -45,9 +45,6 @@ conveyorPoller:
     requests:
       cpu: 750m
       memory: 400Mi
-  config:
-    common:
-      loglevel: "DEBUG"
 
 judgeEvaluator:
   threads: 8


### PR DESCRIPTION
I was investigating why there are some requests which were finished days ago, but not marked as done. According to my latest findings, it looks like an issue in FTS:
- https://cern.service-now.com/service-portal?id=ticket&is_new_order=true&table=incident&sys_id=59827c2797b7d2108a6b34ae2153af0a

This is a PR to revert the changes I've done in receiver count and poller logging level.

@ericvaandering FYI