### PR TITLE
Introduce tape and tier1-disk reapers and make the default reaper work only on T2 and T3 disks

### DIFF
--- a/apps/options/tape-reaper/kustomization.yaml
+++ b/apps/options/tape-reaper/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rucio
+resources:
+  - tape-reaper-daemons-helm.yaml

--- a/apps/options/tape-reaper/tape-reaper-daemons-helm.yaml
+++ b/apps/options/tape-reaper/tape-reaper-daemons-helm.yaml
@@ -1,0 +1,33 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: tape-reaper-daemons
+spec:
+  releaseName: tape-reaper-daemons
+  chart:
+    spec:
+      chart: rucio-daemons
+      version: "<37.0"
+      sourceRef:
+        kind: HelmRepository
+        name: rucio
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: cms-rucio-common
+    - kind: ConfigMap
+      name: cms-rucio-daemons
+    - kind: ConfigMap
+      name: instance-rucio-daemons
+    - kind: ConfigMap
+      name: instance-rucio-release
+    - kind: ConfigMap
+      name: tape-reaper-rucio-daemons
+    - kind: Secret
+      name: rucio-secrets
+      valuesKey: db_string
+      targetPath: config.database.default

--- a/apps/options/tier1-reaper/kustomization.yaml
+++ b/apps/options/tier1-reaper/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rucio
+resources:
+  - tier1-reaper-daemons-helm.yaml

--- a/apps/options/tier1-reaper/tier1-reaper-daemons-helm.yaml
+++ b/apps/options/tier1-reaper/tier1-reaper-daemons-helm.yaml
@@ -1,0 +1,33 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: tier1-reaper-daemons
+spec:
+  releaseName: tier1-reaper-daemons
+  chart:
+    spec:
+      chart: rucio-daemons
+      version: "<37.0"
+      sourceRef:
+        kind: HelmRepository
+        name: rucio
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: cms-rucio-common
+    - kind: ConfigMap
+      name: cms-rucio-daemons
+    - kind: ConfigMap
+      name: instance-rucio-daemons
+    - kind: ConfigMap
+      name: instance-rucio-release
+    - kind: ConfigMap
+      name: tier1-reaper-rucio-daemons
+    - kind: Secret
+      name: rucio-secrets
+      valuesKey: db_string
+      targetPath: config.database.default

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -15,6 +15,8 @@ resources:
   - ../base/cms-rucio-consistency
   - ../base/cms-rucio-cron
   - ../options/tier0-reaper
+  - ../options/tier1-reaper 
+  - ../options/tape-reaper
   - ../options/loadtest-daemons
   - ../options/loadtest
   - ../base/patches
@@ -41,6 +43,12 @@ configMapGenerator:
   - name: tier0-reaper-rucio-daemons
     files:
       - values.yaml=tier0-reaper-rucio-daemons.yaml
+  - name: tier1-reaper-rucio-daemons
+    files:
+      - values.yaml=tier1-reaper-rucio-daemons.yaml
+  - name: tape-reaper-rucio-daemons
+    files:
+      - values.yaml=tape-reaper-rucio-daemons.yaml
   - name: instance-traces
     files:
       - values.yaml=prod-traces.yaml

--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -1,5 +1,5 @@
 # More reapers (or threads) than this cause issues for CERN Oracle, so use only temporarily. Reducing the sleep time is similar
-reaperCount: 8
+reaperCount: 4
 judgeInjectorCount: 2
 judgeRepairerCount: 2
 conveyorTransferSubmitterCount: 3
@@ -29,7 +29,7 @@ replicaRecoverer:
 
 reaper:
   threads: 4
-  includeRses: "reaper=True"
+  includeRses: "cms_type=real&reaper=True\\rse_type=TAPE\\tier=1\\tier0\\T2_CH_CERN"
   chunkSize: 4000
   sleepTime: 120
   config:

--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -29,7 +29,7 @@ replicaRecoverer:
 
 reaper:
   threads: 4
-  includeRses: "cms_type=real&reaper=True\\rse_type=TAPE\\tier=1\\tier0\\T2_CH_CERN"
+  includeRses: "cms_type=real&reaper=True\\rse_type=TAPE\\tier=1\\tier=0\\T2_CH_CERN"
   chunkSize: 4000
   sleepTime: 120
   config:

--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -29,7 +29,7 @@ replicaRecoverer:
 
 reaper:
   threads: 4
-  includeRses: "cms_type=real&reaper=True\\rse_type=TAPE\\tier=1\\tier=0\\T2_CH_CERN"
+  includeRses: "reaper=True\\rse_type=TAPE\\tier=1\\tier=0\\T2_CH_CERN"
   chunkSize: 4000
   sleepTime: 120
   config:

--- a/apps/production/tape-reaper-rucio-daemons.yaml
+++ b/apps/production/tape-reaper-rucio-daemons.yaml
@@ -21,11 +21,11 @@ conveyorReceiverCount: 0
 conveyorThrottlerCount: 0
 replicaRecovererCount: 0
 minosTemporaryExpirationCount: 0
-reaperCount: 2
+reaperCount: 4
 
 reaper:
   threads: 4
-  includeRses: "T0_CH_CERN_Disk|T2_CH_CERN"
+  includeRses: "cms_type=real&rse_type=TAPE&reaper=True"
   chunkSize: 4000
   sleepTime: 120
   config:

--- a/apps/production/tier1-reaper-rucio-daemons.yaml
+++ b/apps/production/tier1-reaper-rucio-daemons.yaml
@@ -21,11 +21,11 @@ conveyorReceiverCount: 0
 conveyorThrottlerCount: 0
 replicaRecovererCount: 0
 minosTemporaryExpirationCount: 0
-reaperCount: 2
+reaperCount: 4
 
 reaper:
   threads: 4
-  includeRses: "T0_CH_CERN_Disk|T2_CH_CERN"
+  includeRses: "cms_type=real&rse_type=DISK&tier=1&reaper=True"
   chunkSize: 4000
   sleepTime: 120
   config:


### PR DESCRIPTION
The default reaper will work on T2 and T3 disks, count: 8->4
Tier1 reaper will work on T1 disks, count: 4
Tape reaper will work on all tapes, count: 4
Tier0 reaper will work on T2_CH_CERN and T0_CH_CERN_Disk as before, count: 1->2

@Panos512 @eachristgr @juanpablosalas FYI