### PR TITLE
loadtest submmiter: increase archive timeout

### DIFF
--- a/apps/production/loadtest-rucio-daemons.yaml
+++ b/apps/production/loadtest-rucio-daemons.yaml
@@ -26,7 +26,7 @@ minosTemporaryExpirationCount: 0
 conveyorTransferSubmitter:
   activities: "'Functional Test'"
   groupBulk: 10
-  archiveTimeout: 3600
+  archiveTimeout: 7200
   ignoreAvailability: true
   threads: 1
 


### PR DESCRIPTION
Following up on [CMSDM-249](https://its.cern.ch/jira/browse/CMSDM-249), it appears that the increment of archive polling interval to 1 hour on FTS [1] has introduced a design issue with the submitter used for _Fuciotnal Test_ activity.

Although loadtests for tapes have been disabled, this submitter is still being used for tape-related SAM and manual tests. Notably, it's the only submitter handling _Fuctional Test_ and the only one leveraging `ignore_availability` option, which allows the submissions regardless of an RSE's the availability status.

Increasing the archive timeout in Rucio side will give FTS sufficient time to update transfers status.

@ericvaandering do you see any downsides to this?

FYI @haozturk 

[1] https://cern.service-now.com/service-portal?id=ticket&n=RQF3151564