### PR TITLE
Enable consistency 4.8.2b in production

### DIFF
--- a/apps/production/prod-consistency.yaml
+++ b/apps/production/prod-consistency.yaml
@@ -15,7 +15,7 @@ reportStorageClass:
   osShareAccessID: 38a148e3-5377-4878-9ac0-e3a95c816684
 image:
   repository: registry.cern.ch/cmsrucio/rucio-consistency
-  tag: release-4.8.1
+  tag: release-4.8.2b
 resources:
   requests:
     memory: 6000Mi


### PR DESCRIPTION
The new image (tag 4.8.2b) has a couple significant changes:

*  The almalinux:9 base is updated (via 'dnf update'), which clears up a large number of vulnerabilities.
* "RUN update-crypto-policies --set DEFAULT:SHA1"  is now part of the image, while 4.8.1 image requires this command to be applied by hand at the pod.

Unlike tag 4.8.1, the new image is expected to be fully functional, no further manual tweaks required.