### PR TITLE
Increase ngnix ingress read and send timeout from 1min to 5min

### DIFF
--- a/apps/base/rucio-server/cms-rucio-server.yaml
+++ b/apps/base/rucio-server/cms-rucio-server.yaml
@@ -37,6 +37,9 @@ ingress:
   annotations:
     nginx.ingress.kubernetes.io/frontend-entry-points: http, https
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
   hosts:
     - cms-rucio.cern.ch
   tls:


### PR DESCRIPTION
Attempt to fix
- https://its.cern.ch/jira/browse/CMSDM-332 
- https://github.com/dmwm/CMSRucio/issues/787

 `rucio rule remove` timeouts after 60 seconds for large rules and I'm suspecting this timeout comes from ngnix ingress controller and this PR increases its timeout to 5 min.