### PR TITLE
Revert "Increase ngnix ingress read and send timeout from 1min to 5min"

### DIFF
--- a/apps/base/rucio-server/cms-rucio-server.yaml
+++ b/apps/base/rucio-server/cms-rucio-server.yaml
@@ -37,9 +37,6 @@ ingress:
   annotations:
     nginx.ingress.kubernetes.io/frontend-entry-points: http, https
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
   hosts:
     - cms-rucio.cern.ch
   tls:


### PR DESCRIPTION
Reverts dmwm/rucio-flux#406

since I discovered that the issue isn't the ingress timeout but httpd timeout: https://github.com/rucio/containers/blob/master/server/httpd.conf.j2#L83