### PR TITLE
Update prod-cms-cron.yaml: OIDC fix

### DIFF
--- a/apps/production/prod-cms-cron.yaml
+++ b/apps/production/prod-cms-cron.yaml
@@ -1,6 +1,9 @@
 cronjobSettings:
   instance: "prod"
 
+oidc:
+  iamServer: https://cms-auth.cern.ch/
+
 image:
   repository: registry.cern.ch/cmsrucio/rucio_client
   tag: "latest"


### PR DESCRIPTION
The oidc.iamServer URL was previously set to `https://cms-auth.web.cern.ch/`. 

Fix OIDC auth by updating IAM server URL to `https://cms-auth.cern.ch/`, tested on integration cluster.