### PR TITLE
Enable consistency 4.8.3 in production

### DIFF
--- a/apps/production/prod-consistency.yaml
+++ b/apps/production/prod-consistency.yaml
@@ -15,7 +15,7 @@ reportStorageClass:
   osShareAccessID: 38a148e3-5377-4878-9ac0-e3a95c816684
 image:
   repository: registry.cern.ch/cmsrucio/rucio-consistency
-  tag: release-4.8.2b
+  tag: release-4.8.3
 resources:
   requests:
     memory: 6000Mi


### PR DESCRIPTION
The new image (tag 4.8.3) updates the OSG module from 3.6 (end of life) to 25-main.  

Still using almalinux:9 and el9 for now, but this may change soon.
