### PR TITLE
Enable consistency 4.8.4 in production

### DIFF
--- a/apps/production/prod-consistency.yaml
+++ b/apps/production/prod-consistency.yaml
@@ -15,7 +15,7 @@ reportStorageClass:
   osShareAccessID: 38a148e3-5377-4878-9ac0-e3a95c816684
 image:
   repository: registry.cern.ch/cmsrucio/rucio-consistency
-  tag: release-4.8.3
+  tag: release-4.8.4
 resources:
   requests:
     memory: 6000Mi


### PR DESCRIPTION
The new image (tag 4.8.4) backports the OSG module from 25-main to 24-main

Cron functionality has been added to the image.

Upgrading the almalinux base from 9 to 10 has been tried, but OSG 25-main requires python3-m2crypto, which is not yet packaged for Alma 10, and building m2crypto from scratch seems like unnecessary during our image build.  To be revisited later, but for now moving from 25-main to 24-main in Alma 9 has a smaller number of CVE vulnerabilities (cf. CERN registry scan).