### PR TITLE
enables DEBUG info in submitter

### DIFF
--- a/apps/production/prod-rucio-daemons.yaml
+++ b/apps/production/prod-rucio-daemons.yaml
@@ -43,6 +43,11 @@ conveyorPoller:
       cpu: 750m
       memory: 400Mi
 
+conveyorTransferSubmitter:
+  config:
+    common:
+      loglevel: "DEBUG"
+
 judgeEvaluator:
   threads: 8
   didLimit: 1000


### PR DESCRIPTION
This is to debug token transfers that fail to be submitted to FNAL FTS