### PR TITLE
enables tier0 reaper deletions on Temp and Test RSEs

### DIFF
--- a/apps/production/tier0-reaper-rucio-daemons.yaml
+++ b/apps/production/tier0-reaper-rucio-daemons.yaml
@@ -25,7 +25,7 @@ reaperCount: 2
 
 reaper:
   threads: 4
-  includeRses: "T0_CH_CERN_Disk|T2_CH_CERN"
+  includeRses: "T0_CH_CERN_Disk|T0_CH_CERN_Disk_Test|T2_CH_CERN|T2_CH_CERN_Test|T2_CH_CERN_Temp"
   chunkSize: 4000
   sleepTime: 120
 


### PR DESCRIPTION
We don't have any reaper deleting on CERN Test and Temp RSEs, since the T0 reaper is only configured for the main RSEs and the general reaper excludes based on the tier attribute so doesn't process deletions on T0_CH_CERN_Disk_Test, T2_CH_CERN_Test and T2_CH_CERN_Temp.

Since there are not many deletions happening on Temp and Test I decide to include those on the dedicated T0 Reaper, but we could also include them in the general one as an alternative.