### PR TITLE
enables T1 reaper for T1 Test and Temp RSEs

### DIFF
--- a/apps/production/tier1-reaper-rucio-daemons.yaml
+++ b/apps/production/tier1-reaper-rucio-daemons.yaml
@@ -25,7 +25,7 @@ reaperCount: 4
 
 reaper:
   threads: 4
-  includeRses: "cms_type=real&rse_type=DISK&tier=1&reaper=True"
+  includeRses: "rse_type=DISK&tier=1&reaper=True"
   chunkSize: 4000
   sleepTime: 120
   config:


### PR DESCRIPTION
Removes the `cms_type=real` filter from the Tier1 reaper RSE expression to include Test and Temp Tier-1 RSEs