### PR TITLE
bumps server memory limits

### DIFF
--- a/apps/base/rucio-server/cms-rucio-server.yaml
+++ b/apps/base/rucio-server/cms-rucio-server.yaml
@@ -68,7 +68,7 @@ serverResources:
   requests:
     memory: 500Mi
   limits:
-    memory: 1500Mi
+    memory: 4500Mi
 
 config:
   common:


### PR DESCRIPTION
It looks like our server pods are restarting all the time because of high memory usage. 
This is from the prometheus server running inside the cluster (we already work on having some monitoring on those metrics)
<img width="1131" height="720" alt="Screenshot 2026-03-26 at 17 14 05" src="https://github.com/user-attachments/assets/7296efaf-a9fd-4351-bbf8-621e1318ecbf" />

The overall memory usage on the cluster seems low

<img width="1448" height="329" alt="Screenshot 2026-03-26 at 17 15 10" src="https://github.com/user-attachments/assets/0543c7a7-b6db-423b-a904-5217cecd3e40" />

I think we can try bumping the limit from 1.5G to 4.5G and see if this helps. For the 3 pods this would be a maximum of 9GBs across the cluster.
Our nodes have 23GB each:

```
  Resource           Requests      Limits
  --------           --------      ------
  cpu                4750m (59%)   11570m (144%)
  memory             8238Mi (58%)  23390Mi (165%)
```

What do you guys think, would it be OK to try increasing the limits? @haozturk @ericvaandering 
