### PR TITLE
Int lpaciose hash tokens patch

### DIFF
--- a/apps/base/patches/hash-tokens.patch
+++ b/apps/base/patches/hash-tokens.patch
@@ -1,0 +1,64 @@
+From 8b50bc3eaed9d9df560e03bfebf85dee7fce0f1d Mon Sep 17 00:00:00 2001
+From: maany <imptodefeat@gmail.com>
+Date: Mon, 13 Apr 2026 13:07:52 +0200
+Subject: [PATCH] fix(Auth): hash tokens for cache keys to prevent exposure
+
+Use SHA-256 to hash authentication tokens before using them as cache
+keys. This prevents token exposure in the cache backend and ensures
+consistent key length (64 chars) that works with both Rucio tokens
+and long JWT tokens.
+
+Issue: #8485
+---
+ lib/rucio/core/authentication.py | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/lib/rucio/core/authentication.py b/lib/rucio/core/authentication.py
+index c1680c8105..cc549c2b72 100644
+--- a/lib/rucio/core/authentication.py
++++ b/lib/rucio/core/authentication.py
+@@ -81,6 +81,19 @@ def generate_key(token, *, session: "Session"):
+     return generate_key
+ 
+ 
++def _hash_token_for_cache(token: str) -> str:
++    """
++    Hash token to create a safe cache key.
++
++    This prevents token exposure in cache and ensures consistent key length
++    (64 chars) that works with both Rucio tokens and long JWT tokens.
++
++    :param token: Authentication token to hash
++    :returns: SHA-256 hash of the token as a hex string (64 characters)
++    """
++    return hashlib.sha256(token.encode('utf-8')).hexdigest()
++
++
+ if config_get_bool('cache', 'use_external_cache_for_auth_tokens', default=False):
+     TOKENREGION = MemcacheRegion(expiration_time=900, function_key_generator=token_key_generator)
+ else:
+@@ -498,11 +511,14 @@ def validate_auth_token(token: str, *, session: "Session") -> "TokenValidationDi
+ 
+     # Be gentle with bash variables, there can be whitespace
+     token = token.strip()
+-    cache_key = token.replace(' ', '')
++
++    # Hash token for cache key to prevent exposure and handle long JWT tokens
++    cache_key = _hash_token_for_cache(token)
+ 
+     # Check if token can be found in cache region
+     value: Union[NoValue, "TokenValidationDict"] = TOKENREGION.get(cache_key)
+     if value is NO_VALUE:  # no cached entry found
++        # Query database using the original token (not the hash)
+         value = query_token(token, session=session)
+         if not value:
+             # identify JWT access token and validate
+@@ -513,7 +529,7 @@ def validate_auth_token(token: str, *, session: "Session") -> "TokenValidationDi
+                 value = validate_jwt(token, session=session)
+             else:
+                 raise CannotAuthenticate(traceback.format_exc())
+-        # save token in the cache
++        # save token validation result in cache using hashed key
+         TOKENREGION.set(cache_key, value)
+     lifetime = value.get('lifetime', datetime.datetime(1970, 1, 1))  # type: ignore (value is narrowed to dict, but type-checker doesn't see it)
+     if lifetime < datetime.datetime.utcnow():  # check if expired

--- a/apps/base/patches/kustomization.yaml
+++ b/apps/base/patches/kustomization.yaml
@@ -17,3 +17,8 @@ secretGenerator:
       disableNameSuffixHash: true
     files:
       -  server-debug.patch
+  - name: hash-tokens-patch
+    options:
+      disableNameSuffixHash: true
+    files:
+      -  hash-tokens.patch

--- a/apps/base/rucio-authserver/cms-rucio-authserver.yaml
+++ b/apps/base/rucio-authserver/cms-rucio-authserver.yaml
@@ -26,6 +26,10 @@ secretMounts:
   - secretFullName: idpsecrets
     mountPath: /opt/rucio/etc/idpsecrets.json
     subPath: idpsecrets.json
+  # Patches for servers go here
+  - secretFullName: hash-tokens-patch
+    mountPath: /patch/hash-tokens.patch
+    subPath: hash-tokens.patch
 
 optional_config:
   rucio_ca_path: "/cvmfs/grid.cern.ch/etc/grid-security/certificates/"

--- a/apps/base/rucio-server/cms-rucio-server.yaml
+++ b/apps/base/rucio-server/cms-rucio-server.yaml
@@ -29,6 +29,9 @@ secretMounts:
   - secretFullName: server-debug-patch
     mountPath: /patch/server-debug.patch
     subPath: server-debug.patch
+  - secretFullName: hash-tokens-patch
+    mountPath: /patch/hash-tokens.patch
+    subPath: hash-tokens.patch
 
 optional_config:
   rucio_ca_path: "/cvmfs/grid.cern.ch/etc/grid-security/certificates/"


### PR DESCRIPTION
Added patch `/apps/base/patches/hash-tokens.patch`, taken from PR#8486 in rucio/rucio https://github.com/rucio/rucio/pull/8486, to hash auth tokens:

1. prevents token exposure in the cache backend 
2. ensures consistent key length (64 chars) that works with both Rucio tokens and long JWT tokens
