### PR TITLE
Updated cron jobs helm chart

### DIFF
--- a/apps/base/cms-rucio-cron/cms-rucio-cron-helm.yaml
+++ b/apps/base/cms-rucio-cron/cms-rucio-cron-helm.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: helm/rucio-cron-jobs
-      version: 2.2.1
+      version: 4.0.0
       sourceRef:
         kind: HelmRepository
         name: cms-rucio-oci


### PR DESCRIPTION
This helm chart version bump should pick up the monitoring cronjob changes added in [1] as part of our efforts to move DMOps cronjobs to production and managing via flux [2]. This change ([1]) only includes the `rucio-subscriptions` cronjob but once this one is tested we will include the others corresponding to [3].


[1] https://github.com/dmwm/CMSRucio/pull/910
[2] https://github.com/dmwm/CMSRucio/issues/904
[3] https://github.com/dmwm/CMSRucio/pull/1049