### PR TITLE
Resource read-only request for MCP service account

### DIFF
--- a/apps/integration/int-rucio-sa-read-only.yaml
+++ b/apps/integration/int-rucio-sa-read-only.yaml
@@ -13,6 +13,7 @@ rules:
   - ""  
   resources:  
   - pods  
+  - pods/log
   - services  
   - configmaps  
   - secrets  

--- a/apps/integration/int-rucio-sa-read-only.yaml
+++ b/apps/integration/int-rucio-sa-read-only.yaml
@@ -14,23 +14,80 @@ rules:
   resources:  
   - pods  
   - pods/log
+  - events
   - services  
+  - endpoints
   - configmaps  
-  - secrets  
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - namespaces
+  - nodes
   verbs:  
   - get  
   - list  
   - watch  
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:  
   - apps  
   resources:  
   - deployments  
+  - replicasets
   - statefulsets  
-  - daemonsets  
+  - daemonsets
+  - controllerrevisions  
   verbs:  
   - get  
   - list  
-  - watch  
+  - watch 
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list 
 ---  
 apiVersion: rbac.authorization.k8s.io/v1  
 kind: ClusterRoleBinding  


### PR DESCRIPTION
### Summary

This PR expands the read-only Kubernetes `ClusterRole` that will be used for the Kubernetes MCP server. The goal is to provide enough visibility for AI agents to understand the state of a cluster, diagnose deployment issues, and answer operational questions, while maintaining a strictly read-only security posture.

The role grants only the get, list, and watch verbs. It does not allow creating, modifying, deleting, or executing resources in the cluster.

### Security considerations

#### Read-only access

Every permission is limited to: [`get`,`list`,`watch`]. The role **CANNOT** create/update/patch/delete resources, exec into containers, port-forward, copy files, modify RBAC, and in general access the Kubernetes API beyond read operations. As a result, an agent using these credentials cannot make changes to the cluster.

#### Secrets are not accessible

The role intentionally does not grant access to `secrets`. This means the MCP CANNOT retrieve Kubernetes secrets, service account tokens, passwords, API keys or cloud/database credentials.

Since Secret objects are inaccessible, there is no direct path for the MCP to retrieve sensitive credentials stored within Kubernetes.

#### Pod logs

The only potentially sensitive resource exposed is pods/log, which is _crucial_ for diagnosing application failures. Even if these logs are also accessible via OpenSearch (`monit-timberprivate`), these are also needed here in order to obtain a more comprehensive diagnosis and monitoring of the pods. AFAIK, we should avoid writing any credentials to logs, but in the case that these are written, the MCP can be configured to redact common secret patterns before presenting the log output to an agent for an additional layer of protection. I took a look at the current `rucio` integration pods and they do not expose any secrets.

### What it can do

With the permissions granted, the service account (later the MCP) will have access to:

**Core resources**

- Pods: Inspect workload state, status, scheduling, container information, conditions, and events.
- Pod logs: Help diagnose application failures that cannot be determined from object status alone (startup failures, configuration errors, stack traces, etc.).
- Events: Surface scheduling failures, image pull errors, probe failures, and other Kubernetes-generated diagnostics.
- Services / Endpoints / EndpointSlices: Understand service discovery and traffic routing.
- ConfigMaps: Identify configuration references and explain how applications are configured.
- PersistentVolumeClaims: Detect storage binding issues.
- ReplicationControllers: Included for compatibility with older workloads.
- Namespaces: Discover cluster organization.
- Nodes: Determine scheduling decisions and node health.

**Networking resources**
- Ingresses: Explain external routing.
- NetworkPolicies: Diagnose connectivity restrictions.

**Metrics**

Read-only access to the Metrics API allows the MCP to answer questions about current CPU and memory usage for Pods and Nodes, which is frequently required when troubleshooting performance or scheduling issues.