### PR TITLE
set RUCIO_HTTP_ENCODED_SLASHES_NO_DECODE to true

### DIFF
--- a/apps/base/rucio-server/cms-rucio-server.yaml
+++ b/apps/base/rucio-server/cms-rucio-server.yaml
@@ -90,3 +90,5 @@ persistentVolumes:
 additionalEnvs:
   - name: X509_USER_PROXY
     value: "/opt/proxy/x509up"
+  - name: RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE
+    value: "true"


### PR DESCRIPTION
Since httpd_config.encoded_slashes is "True", URL encoding characters stay in the did Rucio Python only unquotes that if RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE=true


The second solution is to evaluate whether we need the `encoded_slashes` setting to be true.