### PR TITLE
adds memory limits for fts-renew cronjob

### DIFF
--- a/apps/base/cms-rucio-common.yaml
+++ b/apps/base/cms-rucio-common.yaml
@@ -65,3 +65,10 @@ ftsRenewal:
       value: "usercert.pem"
     - name: USERKEY_NAME
       value: "new_userkey.pem"
+  resources:
+    limits:
+      cpu: 1250m
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi


### PR DESCRIPTION
The server-renew-fts-proxy cronjob was inheriting the chart default of 256Mi, which is no longer enough to load the IGTF CRLs into memory. HARICA recently grew their GEANT TLS CRLs and the job started getting OOM-killed while initialising the trust anchors.

Because the proxy is valid for 96h but renewed every 6h, this failed silently for ~20 runs before the last valid proxy expired and FTS submissions started failing.

This MR sets ftsRenewal.resources to 2Gi limit / 512Mi request in the shared base values, so both production and integration pick it up. The job runs for about a minute every 6 hours, so the extra headroom costs nothing.

