### PR TITLE
Set shell `NODE_EXTRA_CA_CERTS`

### DIFF
--- a/apps/base/rucio-newui/cms-rucio-newui.yaml
+++ b/apps/base/rucio-newui/cms-rucio-newui.yaml
@@ -73,6 +73,8 @@ additionalEnvs:
     value: "/cvmfs/grid.cern.ch/etc/grid-security/certificates"
   - name: RUCIO_WEBUI_SERVER_CA_BUNDLE
     value: "/etc/grid-security/CERN-bundle.pem"
+  - name: NODE_EXTRA_CA_CERTS
+    value: "/etc/grid-security/CERN-bundle.pem"
   - name: RUCIO_SSL_PROTOCOL
     value: "-SSLv3 -TLSv1 -TLSv1.1 +TLSv1.2"
 

--- a/apps/integration/int-rucio-newui.yaml
+++ b/apps/integration/int-rucio-newui.yaml
@@ -31,7 +31,6 @@ config:
     oidc_providers: "cms"
     oidc_expected_audience: "rucio"
     server_ca_bundle: "/etc/grid-security/CERN-bundle.pem"
-    node_tls_reject_unauthorized: 0
   
   oidc_providers:
       cms:


### PR DESCRIPTION
Setting the NODE_EXTRA_CA_CERTS environment variable directly in the shell, as Node.js does not appear to pick it up from the .env file. Without setting it in the shell, data retrieval fails and OIDC authentication cannot complete.