### PR TITLE
bump up rucio cron jobs to include monitoring

### DIFF
--- a/apps/base/cms-rucio-cron/cms-rucio-cron-helm.yaml
+++ b/apps/base/cms-rucio-cron/cms-rucio-cron-helm.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: helm/rucio-cron-jobs
-      version: 2.2.1
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: cms-rucio-oci


### PR DESCRIPTION
I assume this is the correct way to do include https://github.com/dmwm/CMSRucio/pull/1049 unless we want to test this in integration first (which is running v 3.1.9 and not handled through flux commits I believe)